### PR TITLE
Fix import issue

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -1126,6 +1126,9 @@ static InterpretResult run(VM *vm) {
             if (function == NULL) return INTERPRET_COMPILE_ERROR;
             push(vm, OBJ_VAL(function));
             ObjClosure *closure = newClosure(vm, function);
+            pop(vm);
+
+            push(vm, OBJ_VAL(closure));
 
             frame->ip = ip;
             call(vm, closure, 0);

--- a/c/vm.c
+++ b/c/vm.c
@@ -1126,7 +1126,6 @@ static InterpretResult run(VM *vm) {
             if (function == NULL) return INTERPRET_COMPILE_ERROR;
             push(vm, OBJ_VAL(function));
             ObjClosure *closure = newClosure(vm, function);
-            pop(vm);
 
             frame->ip = ip;
             call(vm, closure, 0);


### PR DESCRIPTION
# Fix import issue
Resolves #238 
## Summary
This PR resolves the issue with importing. Currently when an import happens a closure object is created however it is not pushed onto the stack. When the closure is called the vm frames may need to grow in capacity which in turn could therefore trigger a GC. We need to make sure the closure is not lost to the GC.