### PR TITLE
Add support for `_` as a delimiter in numbers.

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -671,7 +671,8 @@ static void number(Compiler *compiler, bool canAssign) {
     UNUSED(canAssign);
 
     // We allocate the whole range for the worst case.
-    char* buffer = (char *)calloc(compiler->parser->previous.length, sizeof(char));
+    // Also account for the null-byte.
+    char* buffer = (char *)malloc((compiler->parser->previous.length + 1) * sizeof(char));
     char* current = buffer;
 
     // Strip it of any underscores.
@@ -690,7 +691,7 @@ static void number(Compiler *compiler, bool canAssign) {
     double value = strtod(buffer, NULL);
     emitConstant(compiler, NUMBER_VAL(value));
 
-    // Free the calloc'd buffer.
+    // Free the malloc'd buffer.
     free(buffer);
 }
 

--- a/c/compiler.c
+++ b/c/compiler.c
@@ -670,8 +670,28 @@ static void grouping(Compiler *compiler, bool canAssign) {
 static void number(Compiler *compiler, bool canAssign) {
     UNUSED(canAssign);
 
-    double value = strtod(compiler->parser->previous.start, NULL);
+    // We allocate the whole range for the worst case.
+    char* buffer = (char *)calloc(compiler->parser->previous.length, sizeof(char));
+    char* current = buffer;
+
+    // Strip it of any underscores.
+    for(int i = 0; i < compiler->parser->previous.length; i++) {
+        char c = compiler->parser->previous.start[i];
+
+        if (c != '_') {
+            *(current++) = c;
+        }
+    }
+
+    // Terminate the string with a null character.
+    *current = '\0';
+
+    // Parse the string.
+    double value = strtod(buffer, NULL);
     emitConstant(compiler, NUMBER_VAL(value));
+
+    // Free the calloc'd buffer.
+    free(buffer);
 }
 
 static void or_(Compiler *compiler, bool canAssign) {

--- a/c/scanner.c
+++ b/c/scanner.c
@@ -280,7 +280,7 @@ static Token identifier() {
 }
 
 static Token number() {
-    while (isDigit(peek())) advance();
+    while (isDigit(peek()) || peek() == '_') advance();
 
     // Look for a fractional part.
     if (peek() == '.' && isDigit(peekNext())) {

--- a/c/scanner.c
+++ b/c/scanner.c
@@ -287,7 +287,7 @@ static Token number() {
         // Consume the "."
         advance();
 
-        while (isDigit(peek())) advance();
+        while (isDigit(peek()) || peek() == '_') advance();
     }
 
     return makeToken(TOKEN_NUMBER);

--- a/tests/maths/maths.du
+++ b/tests/maths/maths.du
@@ -28,6 +28,7 @@ assert(Math.abs(-18) == 18);
 assert(Math.sqrt(25) == 5);
 assert(Math.sqrt(100) == 10);
 assert(Math.sqrt(20) == 4.47213595499958);
+assert(Math.sqrt(100_00) == 1_00);
 
 assert(Math.PI == 3.14159265358979);
 assert(Math.e == 2.71828182845905);

--- a/tests/number/toBool.du
+++ b/tests/number/toBool.du
@@ -9,3 +9,4 @@
 assert(1.toBool() == true);
 assert(0.toBool() == false);
 assert(11.1.toBool() == true);
+assert(11_1.1.toBool() == true);

--- a/tests/number/toString.du
+++ b/tests/number/toString.du
@@ -12,4 +12,8 @@ assert(11.1.toString() == "11.1");
 var testnum = 123;
 assert(testnum.toString() == "123");
 
+// Check underscore parsing.
+assert(100_000.toString() == "100000");
+assert(100_001.901.toString() == "100001.901");
+
 /* TODO: add more */


### PR DESCRIPTION
Implements the feature as in #271 .

Added relevant tests, and checked for leaks and such.
Note: The underscore can only occur in the non fractional part of a number, this was an intentional choice. If you want me to modify it so that it can appear even in the fractional part I will happily implement that.