### PR TITLE
Add windows to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,17 +95,17 @@ jobs:
              cmake -DCMAKE_BUILD_TYPE=Debug -B ./build
              cmake --build ./build
              ./build/Dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
-  test-windows-cmake:
-    name: Test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-2019, windows-latest]
+     test-windows-cmake:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [windows-2019, windows-latest]
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Make dictu and run tests (No HTTP)
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
-          cmake --build build
-          build\Debug\Dictu.exe tests/runTests.du
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP No Linenoise)
+           run: |
+             cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
+             cmake --build build
+             build\Debug\Dictu.exe tests/runTests.du

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,45 +7,105 @@ on:
       - master
 
 jobs:
-  test-ubuntu:
+     test-ubuntu:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04]
+
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP)
+           run: |
+             make debug DISABLE_HTTP=1
+             ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+         - name: Remove build directory
+           run: |
+             rm -rf build
+         - name: Make dictu and run tests (HTTP)
+           run: |
+             sudo apt-get update
+             sudo apt-get install -y libcurl4-openssl-dev
+             make debug
+             ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+     test-ubuntu-cmake:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04]
+
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP)
+           run: |
+             cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -B ./build
+             cmake --build ./build
+             ./build/Dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+         - name: Remove build directory
+           run: |
+             rm -rf build
+         - name: Make dictu and run tests (HTTP)
+           run: |
+             sudo apt-get update
+             sudo apt-get install -y libcurl4-openssl-dev
+             cmake -DCMAKE_BUILD_TYPE=Debug -B ./build
+             cmake --build ./build
+             ./build/Dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+     test-mac:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [macOS-latest]
+
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP)
+           run: |
+             make debug DISABLE_HTTP=1
+             ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+         - name: Remove build directory
+           run: |
+             rm -rf build
+         - name: Make dictu and run tests
+           run: |
+             make debug
+             ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+     test-mac-cmake:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [macOS-latest]
+
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP)
+           run: |
+             cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -B ./build
+             cmake --build ./build
+             ./build/Dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+         - name: Remove build directory
+           run: |
+             rm -rf build
+         - name: Make dictu and run tests
+           run: |
+             cmake -DCMAKE_BUILD_TYPE=Debug -B ./build
+             cmake --build ./build
+             ./build/Dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+  test-windows-cmake:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04]
+        os: [windows-2019, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
       - name: Make dictu and run tests (No HTTP)
         run: |
-          make debug DISABLE_HTTP=1
-          ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
-      - name: Remove build directory
-        run: |
-          rm -rf build
-      - name: Make dictu and run tests (HTTP)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-          make debug
-          ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
-  test-mac:
-    name: Test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Make dictu and run tests (No HTTP)
-        run: |
-          make debug DISABLE_HTTP=1
-          ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
-      - name: Remove build directory
-        run: |
-          rm -rf build
-      - name: Make dictu and run tests
-        run: |
-          make debug
-          ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+          cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
+          cmake --build build
+          build\Debug\Dictu.exe tests/runTests.du

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(Dictu C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_EXTENSIONS ON)
 
 set(DISABLE_HTTP OFF CACHE BOOL "Determines if HTTPS based features are compiled. HTTPS based features require cURL.")
 set(DISABLE_LINENOISE OFF CACHE BOOL "Determines if the REPL uses linenoise. Linenoise requires termios.")

--- a/README.md
+++ b/README.md
@@ -20,14 +20,52 @@ Dictu means `simplistic` in Latin.
 Documentation for Dictu can be found [here](https://dictu-lang.com/)
 
 ## Running Dictu
+Dictu currently has two options when building, there is a CMakeLists file included so the build files can be generated with
+CMake or there is an included makefile for users that are more familiar with that.
+
+### CMake
 ```bash
-$ git clone https://github.com/Jason2605/Dictu.git
+$ git clone https://github.com/dictu-lang/Dictu.git
+$ cd Dictu
+$ cmake -DCMAKE_BUILD_TYPE=Release -B ./build 
+$ cmake --build ./build
+$ ./build/Dictu
+```
+
+#### Compiling without HTTP
+
+The HTTP class within Dictu requires [cURL](https://curl.haxx.se/) to be installed when building the interpreter. If you wish to
+build Dictu without cURL, and in turn the HTTP class, build with the `DISABLE_HTTP` flag.
+
+```bash
+$ git clone https://github.com/dictu-lang/Dictu.git
+$ cd Dictu
+$ cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_HTTP=1 -B ./build 
+$ cmake --build ./build
+$ ./build/Dictu
+```
+
+#### Compiling without linenoise
+[Linenoise](https://github.com/antirez/linenoise) is used within Dictu to enhance the REPL, however it does not build on windows
+systems so a simpler REPL solution is used.
+
+```bash
+$ git clone https://github.com/dictu-lang/Dictu.git
+$ cd Dictu
+$ cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_LINENOISE=1 -B ./build 
+$ cmake --build ./build
+$ ./build/Dictu
+```
+
+### Makefile
+```bash
+$ git clone https://github.com/dictu-lang/Dictu.git
 $ cd Dictu
 $ make dictu
 $ ./dictu examples/guessingGame.du
 ```
 
-### Compiling without HTTP
+#### Compiling without HTTP
 
 The HTTP class within Dictu requires [cURL](https://curl.haxx.se/) to be installed when building the interpreter. If you wish to
 build Dictu without cURL, and in turn the HTTP class, build with the `DISABLE_HTTP` flag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,19 @@ Dictu means simplistic in Latin. This is the aim of the language: to be as simpl
 ---
 
 ## Installing Dictu
+All it takes is a couple of lines! Fire up a terminal and copy the following, one by one (without the $).
 
-All it takes is three lines! Fire up a terminal and copy the following, one by one (without the $).
+### CMake
+
+```bash
+$ git clone https://github.com/dictu-lang/Dictu.git
+$ cd Dictu
+$ cmake -DCMAKE_BUILD_TYPE=Release -B ./build 
+$ cmake --build ./build
+$ ./build/Dictu
+```
+
+### Makefile
 
 ```bash
 $ git clone https://github.com/dictu-lang/Dictu.git

--- a/tests/system/setCWD.du
+++ b/tests/system/setCWD.du
@@ -12,7 +12,7 @@ assert(type(cwd) == "string");
 assert(cwd.len() > 0);
 assert(System.setCWD("/") == 0);
 if (System.platform == "windows") {
-    assert(System.getCWD() == "C:\\");
+    assert(System.getCWD() == "C:\\" or System.getCWD() == "D:\\");
 } else {
     assert(System.getCWD() == "/");
 }


### PR DESCRIPTION
# Add windows to Github Actions
Resolves #289 
Resolves #284 
Resolves #283
## Summary
This PR updates Github Actions to also run the test suite on windows OSs. Along with this, it fixes an issue where the interpreter could not be built on Ubuntu 20 by turning on CMake extensions. Lastly it updates the build instructions to include some CMake variants for anyone wishing to generate build files for Dictu with CMake.