### PR TITLE
Fix an issue where multiple calls to the HTTP lib would segfault

### DIFF
--- a/c/common.h
+++ b/c/common.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define UNUSED(__x__) (void) __x__
+
 #define NAN_TAGGING
 #define DEBUG_PRINT_CODE
 #define DEBUG_TRACE_EXECUTION

--- a/c/memory.h
+++ b/c/memory.h
@@ -14,7 +14,7 @@
     ((capacity) < 8 ? 8 : (capacity) * 2)
 
 #define SHRINK_CAPACITY(capacity) \
-    ((capacity) < 16 ? 7 : (capacity) / 2)
+    ((capacity) < 16 ? 8 : (capacity) / 2)
 
 #define GROW_ARRAY(vm, previous, type, oldCount, count) \
     (type*)reallocate(vm, previous, sizeof(type) * (oldCount), \

--- a/c/optionals/http.h
+++ b/c/optionals/http.h
@@ -10,10 +10,9 @@
 
 typedef struct response {
     VM *vm;
-    char *res;
     ObjList *headers;
+    char *res;
     size_t len;
-    size_t headerLen;
     long statusCode;
 } Response;
 

--- a/c/table.c
+++ b/c/table.c
@@ -113,6 +113,7 @@ bool tableSet(VM *vm, Table *table, ObjString *key, Value value) {
 }
 
 bool tableDelete(VM *vm, Table *table, ObjString *key) {
+    UNUSED(vm);
     if (table->count == 0) return false;
 
     int capacityMask = table->capacityMask;
@@ -157,13 +158,6 @@ bool tableDelete(VM *vm, Table *table, ObjString *key) {
         nextEntry->psl--;
         *entry = *nextEntry;
         entry = nextEntry;
-    }
-
-    // TODO: Add constant for table load factor
-    if (table->count - 1 < table->capacityMask * 0.35) {
-        // Figure out the new table size.
-        capacityMask = SHRINK_CAPACITY(table->capacityMask);
-        adjustCapacity(vm, table, capacityMask);
     }
 
     return true;

--- a/c/value.c
+++ b/c/value.c
@@ -8,7 +8,7 @@
 #include "vm.h"
 
 #define TABLE_MAX_LOAD 0.75
-#define TABLE_MIN_LOAD 0.35
+#define TABLE_MIN_LOAD 0.25
 
 void initValueArray(ValueArray *array) {
     array->values = NULL;
@@ -216,7 +216,7 @@ bool dictDelete(VM *vm, ObjDict *dict, Value key) {
 
     if (dict->count - 1 < dict->capacityMask * TABLE_MIN_LOAD) {
         // Figure out the new table size.
-        capacityMask = SHRINK_CAPACITY(dict->capacityMask);
+        capacityMask = SHRINK_CAPACITY(dict->capacityMask + 1) - 1;
         adjustDictCapacity(vm, dict, capacityMask);
     }
 

--- a/c/value.c
+++ b/c/value.c
@@ -318,7 +318,7 @@ bool setDelete(VM *vm, ObjSet *set, Value value) {
 
     if (set->count - 1 < set->capacityMask * TABLE_MIN_LOAD) {
         // Figure out the new table size.
-        int capacityMask = SHRINK_CAPACITY(set->capacityMask);
+        int capacityMask = SHRINK_CAPACITY(set->capacityMask + 1) - 1;
         adjustSetCapacity(vm, set, capacityMask);
     }
 

--- a/c/vm.h
+++ b/c/vm.h
@@ -64,8 +64,6 @@ typedef enum {
 #define OK     0
 #define NOTOK -1
 
-#define UNUSED(__x__) (void) __x__
-
 VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]);
 
 void freeVM(VM *vm);


### PR DESCRIPTION
# HTTP Lib
Resolves #254 
## Summary
Upon testing it was found that the internal string table was being resized as part of a GC and ended up in a loop / freeing strings which should not have been free'd. This PR resolves this issue by not scaling tables down and therefore stopping the looping however it's not the fix i was looking for as this means tables could be massively oversized using more memory than necessary. This PR also fixes a few issues with the HTTP lib where the cleanups were not running where they should have been.

### Notes
- Although this PR does fix the issue, it introduces an issue where tables do not scale down and therefore introduces the potential of memory waste, worth looking into a resolution to this new issue. 