### PR TITLE
Cleanup

### DIFF
--- a/c/datatypes/number.c
+++ b/c/datatypes/number.c
@@ -1,7 +1,5 @@
 #include "number.h"
-#include "../vm.h"
-
-#include <stdlib.h>
+#include "../memory.h"
 
 static Value toStringNumber(VM *vm, int argCount, Value *args) {
     if (argCount != 0) {
@@ -12,17 +10,15 @@ static Value toStringNumber(VM *vm, int argCount, Value *args) {
     double number = AS_NUMBER(args[0]);
     int numberStringLength = snprintf(NULL, 0, "%.15g", number) + 1;
     
-    char *numberString = malloc(numberStringLength);
+    char *numberString = ALLOCATE(vm, char, numberStringLength);
+
     if (numberString == NULL) {
         runtimeError(vm, "Memory error on toString()!");
         return EMPTY_VAL;
     }
     
     snprintf(numberString, numberStringLength, "%.15g", number);
-    Value value = OBJ_VAL(copyString(vm, numberString, numberStringLength - 1));
-
-    free(numberString);
-    return value;
+    return OBJ_VAL(takeString(vm, numberString, numberStringLength - 1));
 }
 
 void declareNumberMethods(VM *vm) {

--- a/c/datatypes/strings.c
+++ b/c/datatypes/strings.c
@@ -39,7 +39,7 @@ static Value formatString(VM *vm, int argCount, Value *args) {
     }
 
     int length = 0;
-    char **replaceStrings = ALLOCATE(vm, char *, argCount);
+    char **replaceStrings = ALLOCATE(vm, char*, argCount);
 
     for (int j = 1; j < argCount + 1; j++) {
         Value value = args[j];
@@ -58,7 +58,7 @@ static Value formatString(VM *vm, int argCount, Value *args) {
     ObjString *string = AS_STRING(args[0]);
 
     int stringLen = string->length + 1;
-    char *tmp = ALLOCATE(vm, char, length);
+    char *tmp = ALLOCATE(vm, char, stringLen);
     char *tmpFree = tmp;
     memcpy(tmp, string->chars, stringLen);
 
@@ -77,8 +77,8 @@ static Value formatString(VM *vm, int argCount, Value *args) {
             free(replaceStrings[i]);
         }
 
-        FREE_ARRAY(vm, char, tmp, length);
-        FREE_ARRAY(vm, char *, replaceStrings, argCount);
+        FREE_ARRAY(vm, char, tmp , stringLen);
+        FREE_ARRAY(vm, char*, replaceStrings, argCount);
         return EMPTY_VAL;
     }
 
@@ -101,12 +101,11 @@ static Value formatString(VM *vm, int argCount, Value *args) {
         free(replaceStrings[i]);
     }
 
-    FREE_ARRAY(vm, char *, replaceStrings, argCount);
+    FREE_ARRAY(vm, char*, replaceStrings, argCount);
     memcpy(newStr + stringLength, tmp, strlen(tmp));
-    newStr[fullLength] = '\0';
     ObjString *newString = takeString(vm, newStr, fullLength - 1);
 
-    FREE_ARRAY(vm, char, tmpFree, length);
+    FREE_ARRAY(vm, char, tmpFree, stringLen);
     return OBJ_VAL(newString);
 }
 

--- a/c/datatypes/strings.c
+++ b/c/datatypes/strings.c
@@ -1,5 +1,4 @@
 #include "strings.h"
-#include "../vm.h"
 #include "../memory.h"
 
 
@@ -40,7 +39,7 @@ static Value formatString(VM *vm, int argCount, Value *args) {
     }
 
     int length = 0;
-    char **replaceStrings = malloc(argCount * sizeof(char *));
+    char **replaceStrings = ALLOCATE(vm, char *, argCount);
 
     for (int j = 1; j < argCount + 1; j++) {
         Value value = args[j];
@@ -59,7 +58,7 @@ static Value formatString(VM *vm, int argCount, Value *args) {
     ObjString *string = AS_STRING(args[0]);
 
     int stringLen = string->length + 1;
-    char *tmp = malloc(stringLen);
+    char *tmp = ALLOCATE(vm, char, length);
     char *tmpFree = tmp;
     memcpy(tmp, string->chars, stringLen);
 
@@ -78,14 +77,14 @@ static Value formatString(VM *vm, int argCount, Value *args) {
             free(replaceStrings[i]);
         }
 
-        free(tmp);
-        free(replaceStrings);
+        FREE_ARRAY(vm, char, tmp, length);
+        FREE_ARRAY(vm, char *, replaceStrings, argCount);
         return EMPTY_VAL;
     }
 
     int fullLength = string->length - count * 2 + length + 1;
     char *pos;
-    char *newStr = malloc(sizeof(char) * fullLength);
+    char *newStr = ALLOCATE(vm, char, fullLength);
     int stringLength = 0;
 
     for (int i = 0; i < argCount; ++i) {
@@ -102,12 +101,12 @@ static Value formatString(VM *vm, int argCount, Value *args) {
         free(replaceStrings[i]);
     }
 
-    free(replaceStrings);
+    FREE_ARRAY(vm, char *, replaceStrings, argCount);
     memcpy(newStr + stringLength, tmp, strlen(tmp));
-    ObjString *newString = copyString(vm, newStr, fullLength - 1);
+    newStr[fullLength] = '\0';
+    ObjString *newString = takeString(vm, newStr, fullLength - 1);
 
-    free(newStr);
-    free(tmpFree);
+    FREE_ARRAY(vm, char, tmpFree, length);
     return OBJ_VAL(newString);
 }
 
@@ -125,9 +124,9 @@ static Value splitString(VM *vm, int argCount, Value *args) {
     ObjString *string = AS_STRING(args[0]);
     char *delimiter = AS_CSTRING(args[1]);
 
-    char *tmp = malloc(string->length + 1);
+    char *tmp = ALLOCATE(vm, char, string->length + 1);
     char *tmpFree = tmp;
-    memcpy(tmp, string->chars, string->length + 1);
+    memcpy(tmp, string->chars, string->length);
     tmp[string->length] = '\0';
     int delimiterLength = strlen(delimiter);
     char *token;
@@ -162,7 +161,7 @@ static Value splitString(VM *vm, int argCount, Value *args) {
     }
     pop(vm);
 
-    free(tmpFree);
+    FREE_ARRAY(vm, char, tmpFree, string->length + 1);
     return OBJ_VAL(list);
 }
 
@@ -251,9 +250,10 @@ static Value replaceString(VM *vm, int argCount, Value *args) {
     int stringLen = strlen(string) + 1;
 
     // Make a copy of the string so we do not modify the original
-    char *tmp = malloc(stringLen);
+    char *tmp = ALLOCATE(vm, char, stringLen + 1);
     char *tmpFree = tmp;
     memcpy(tmp, string, stringLen);
+    tmp[stringLen] = '\0';
 
     // Count the occurrences of the needle so we can determine the size
     // of the string we need to allocate
@@ -266,13 +266,13 @@ static Value replaceString(VM *vm, int argCount, Value *args) {
     tmp = tmpFree;
 
     if (count == 0) {
-        free(tmpFree);
+        FREE_ARRAY(vm, char, tmpFree, stringLen + 1);
         return stringValue;
     }
 
     int length = strlen(tmp) - count * (len - replaceLen) + 1;
     char *pos;
-    char *newStr = malloc(sizeof(char) * length);
+    char *newStr = ALLOCATE(vm, char, length);
     int stringLength = 0;
 
     for (int i = 0; i < count; ++i) {
@@ -288,10 +288,9 @@ static Value replaceString(VM *vm, int argCount, Value *args) {
     }
 
     memcpy(newStr + stringLength, tmp, strlen(tmp));
-    ObjString *newString = copyString(vm, newStr, length - 1);
+    ObjString *newString = takeString(vm, newStr, length - 1);
 
-    free(newStr);
-    free(tmpFree);
+    FREE_ARRAY(vm, char, tmpFree, stringLen + 1);
     return OBJ_VAL(newString);
 }
 
@@ -302,17 +301,14 @@ static Value lowerString(VM *vm, int argCount, Value *args) {
     }
 
     ObjString *string = AS_STRING(args[0]);
-
-    char *temp = malloc(sizeof(char) * (string->length + 1));
+    char *temp = ALLOCATE(vm, char, string->length + 1);
 
     for (int i = 0; string->chars[i]; i++) {
         temp[i] = tolower(string->chars[i]);
     }
     temp[string->length] = '\0';
 
-    Value ret = OBJ_VAL(copyString(vm, temp, string->length));
-    free(temp);
-    return ret;
+    return OBJ_VAL(takeString(vm, temp, string->length));
 }
 
 static Value upperString(VM *vm, int argCount, Value *args) {
@@ -322,17 +318,14 @@ static Value upperString(VM *vm, int argCount, Value *args) {
     }
 
     ObjString *string = AS_STRING(args[0]);
-
-    char *temp = malloc(sizeof(char) * (string->length + 1));
+    char *temp = ALLOCATE(vm, char, string->length + 1);
 
     for (int i = 0; string->chars[i]; i++) {
         temp[i] = toupper(string->chars[i]);
     }
     temp[string->length] = '\0';
 
-    Value ret = OBJ_VAL(copyString(vm, temp, string->length));
-    free(temp);
-    return ret;
+    return OBJ_VAL(takeString(vm, temp, string->length));
 }
 
 static Value startsWithString(VM *vm, int argCount, Value *args) {
@@ -381,7 +374,7 @@ static Value leftStripString(VM *vm, int argCount, Value *args) {
 
     ObjString *string = AS_STRING(args[0]);
     int i, count = 0;
-    char *temp = malloc(sizeof(char) * (string->length + 1));
+    char *temp = ALLOCATE(vm, char, string->length + 1);
 
     for (i = 0; i < string->length; ++i) {
         if (!isspace(string->chars[i])) {
@@ -390,10 +383,11 @@ static Value leftStripString(VM *vm, int argCount, Value *args) {
         count++;
     }
 
+    // We need to remove the stripped chars from the count
+    // Will be free'd at the call of takeString
+    vm->bytesAllocated -= count;
     memcpy(temp, string->chars + count, string->length - count);
-    Value ret = OBJ_VAL(copyString(vm, temp, string->length - count));
-    free(temp);
-    return ret;
+    return OBJ_VAL(takeString(vm, temp, string->length - count));
 }
 
 static Value rightStripString(VM *vm, int argCount, Value *args) {
@@ -404,7 +398,7 @@ static Value rightStripString(VM *vm, int argCount, Value *args) {
 
     ObjString *string = AS_STRING(args[0]);
     int length;
-    char *temp = malloc(sizeof(char) * (string->length + 1));
+    char *temp = ALLOCATE(vm, char, string->length + 1);
 
     for (length = string->length - 1; length > 0; --length) {
         if (!isspace(string->chars[length])) {
@@ -412,10 +406,12 @@ static Value rightStripString(VM *vm, int argCount, Value *args) {
         }
     }
 
+    // We need to remove the stripped chars from the count
+    // Will be free'd at the call of takeString
+    vm->bytesAllocated -= string->length - length - 1;
     memcpy(temp, string->chars, length + 1);
-    Value ret = OBJ_VAL(copyString(vm, temp, length + 1));
-    free(temp);
-    return ret;
+    temp[length + 1] = '\0';
+    return OBJ_VAL(takeString(vm, temp, length + 1));
 }
 
 static Value stripString(VM *vm, int argCount, Value *args) {

--- a/c/main.c
+++ b/c/main.c
@@ -15,7 +15,7 @@ void cleanupSockets(void) {
 #endif
 
 #include "common.h"
-#include "vm.h"
+#include "memory.h"
 #include "util.h"
 
 #define VERSION "Dictu Version: 0.11.0\n"
@@ -159,7 +159,7 @@ static void repl(VM *vm, int argc, const char *argv[]) {
 static void runFile(VM *vm, int argc, const char *argv[]) {
     UNUSED(argc);
 
-    char *source = readFile(argv[1]);
+    char *source = readFile(vm, argv[1]);
 
     if (source == NULL) {
         fprintf(stderr, "Could not open file \"%s\".\n", argv[1]);
@@ -167,7 +167,7 @@ static void runFile(VM *vm, int argc, const char *argv[]) {
     }
 
     InterpretResult result = interpret(vm, source);
-    free(source); // [owner]
+    FREE_ARRAY(vm, char, source, strlen(source) + 1);
 
     if (result == INTERPRET_COMPILE_ERROR) exit(65);
     if (result == INTERPRET_RUNTIME_ERROR) exit(70);

--- a/c/optionals/c.c
+++ b/c/optionals/c.c
@@ -49,7 +49,7 @@ Value strerrorNative(VM *vm, int argCount, Value *args) {
     return strerrorGeneric(vm, error);
 }
 
-void createCClass(VM *vm) {
+void createCModule(VM *vm) {
     ObjString *name = copyString(vm, "C", 1);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/c.h
+++ b/c/optionals/c.h
@@ -35,7 +35,7 @@
 #include "../vm.h"
 #include "../memory.h"
 
-void createCClass(VM *vm);
+void createCModule(VM *vm);
 
 #define MAX_ERROR_LEN 256
 Value strerrorGeneric(VM *, int);

--- a/c/optionals/datetime.c
+++ b/c/optionals/datetime.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <stdlib.h>
 
 #include "datetime.h"
@@ -157,7 +156,7 @@ static Value strptimeNative(VM *vm, int argCount, Value *args) {
 }
 #endif
 
-ObjModule *createDatetimeClass(VM *vm) {
+ObjModule *createDatetimeModule(VM *vm) {
     ObjString *name = copyString(vm, "Datetime", 8);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/datetime.c
+++ b/c/optionals/datetime.c
@@ -84,7 +84,7 @@ static Value strftimeNative(VM *vm, int argCount, Value *args) {
     struct tm tictoc;
     int len = (format->length > 128 ? format->length * 4 : 128);
 
-    char *point = malloc(len);
+    char *point = ALLOCATE(vm, char, len);
     if (point == NULL) {
         runtimeError(vm, "Memory error on strftime()!");
         return EMPTY_VAL;
@@ -98,36 +98,33 @@ static Value strftimeNative(VM *vm, int argCount, Value *args) {
      * there is a big enough buffer.
      */
 
-    /** however is not guaranteed that 0 indicates a failure (`man strftime' says so).
+     /** however is not guaranteed that 0 indicates a failure (`man strftime' says so).
      * So we might want to catch up the eternal loop, by using a maximum iterator.
      */
-
-    ObjString *res;
-
     int max_iterations = 8;  // maximum 65536 bytes with the default 128 len,
                              // more if the given string is > 128
     int iterator = 0;
     while (strftime(point, sizeof(char) * len, fmt, &tictoc) == 0) {
         if (++iterator > max_iterations) {
-            res = copyString(vm, "", 0);
-            goto theend;
+            FREE_ARRAY(vm, char, point, len);
+            return OBJ_VAL(copyString(vm, "", 0));
         }
 
         len *= 2;
 
-        point = realloc(point, len);
+        point = GROW_ARRAY(vm, point, char, len / 2, len);
         if (point == NULL) {
             runtimeError(vm, "Memory error on strftime()!");
             return EMPTY_VAL;
         }
     }
 
-    res = copyString(vm, point, strlen(point));
+    int length = strlen(point);
 
-theend:
-    free(point);
+    // Account for the buffer created at the start
+    vm->bytesAllocated -= len - length - 1;
 
-    return OBJ_VAL(res);
+    return OBJ_VAL(takeString(vm, point, length));
 }
 
 #ifdef HAS_STRPTIME

--- a/c/optionals/datetime.h
+++ b/c/optionals/datetime.h
@@ -8,6 +8,6 @@
 
 #include "optionals.h"
 
-ObjModule *createDatetimeClass(VM *vm);
+ObjModule *createDatetimeModule(VM *vm);
 
 #endif //dictu_datetime_h

--- a/c/optionals/env.c
+++ b/c/optionals/env.c
@@ -68,7 +68,7 @@ static Value set(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(retval == 0 ? OK : NOTOK);
 }
 
-ObjModule *createEnvClass(VM *vm) {
+ObjModule *createEnvModule(VM *vm) {
     ObjString *name = copyString(vm, "Env", 3);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/env.h
+++ b/c/optionals/env.h
@@ -7,6 +7,6 @@
 #include "optionals.h"
 #include "../vm.h"
 
-ObjModule *createEnvClass(VM *vm);
+ObjModule *createEnvModule(VM *vm);
 
 #endif //dictu_env_h

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -313,7 +313,7 @@ static Value post(VM *vm, int argCount, Value *args) {
     return NIL_VAL;
 }
 
-ObjModule *createHTTPClass(VM *vm) {
+ObjModule *createHTTPModule(VM *vm) {
     ObjString *name = copyString(vm, "HTTP", 4);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -24,8 +24,7 @@ static void createResponse(VM *vm, Response *response) {
     push(vm, OBJ_VAL(response->headers));
 
     response->len = 0;
-    response->res = malloc(1);
-    response->res[0] = '\0';
+    response->res = NULL;
 }
 
 static size_t writeResponse(char *ptr, size_t size, size_t nmemb, Response *response) {

--- a/c/optionals/http.h
+++ b/c/optionals/http.h
@@ -16,6 +16,6 @@ typedef struct response {
     long statusCode;
 } Response;
 
-ObjModule *createHTTPClass(VM *vm);
+ObjModule *createHTTPModule(VM *vm);
 
 #endif //dictu_http_h

--- a/c/optionals/json.c
+++ b/c/optionals/json.c
@@ -263,7 +263,7 @@ static Value stringify(VM *vm, int argCount, Value *args) {
     return OBJ_VAL(string);
 }
 
-ObjModule *createJSONClass(VM *vm) {
+ObjModule *createJSONModule(VM *vm) {
     ObjString *name = copyString(vm, "JSON", 4);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/json.h
+++ b/c/optionals/json.h
@@ -6,6 +6,6 @@
 #include "optionals.h"
 #include "../vm.h"
 
-ObjModule *createJSONClass(VM *vm);
+ObjModule *createJSONModule(VM *vm);
 
 #endif //dictu_json_h

--- a/c/optionals/math.c
+++ b/c/optionals/math.c
@@ -221,7 +221,7 @@ static Value tanNative(VM *vm, int argCount, Value *args) {
     return NUMBER_VAL(tan(AS_NUMBER(args[0])));
 }
 
-ObjModule *createMathsClass(VM *vm) {
+ObjModule *createMathsModule(VM *vm) {
     ObjString *name = copyString(vm, "Math", 4);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/math.h
+++ b/c/optionals/math.h
@@ -6,6 +6,6 @@
 #include "optionals.h"
 #include "../vm.h"
 
-ObjModule *createMathsClass(VM *vm);
+ObjModule *createMathsModule(VM *vm);
 
 #endif //dictu_math_h

--- a/c/optionals/optionals.c
+++ b/c/optionals/optionals.c
@@ -1,15 +1,15 @@
 #include "optionals.h"
 
 BuiltinModules modules[] = {
-        {"Math", &createMathsClass},
-        {"Env", &createEnvClass},
-        {"JSON", &createJSONClass},
-        {"Path", &createPathClass},
-        {"Datetime", &createDatetimeClass},
-        {"Socket", &createSocketClass},
-        {"Random", &createRandomClass},
+        {"Math", &createMathsModule},
+        {"Env", &createEnvModule},
+        {"JSON", &createJSONModule},
+        {"Path", &createPathModule},
+        {"Datetime", &createDatetimeModule},
+        {"Socket", &createSocketModule},
+        {"Random", &createRandomModule},
 #ifndef DISABLE_HTTP
-        {"HTTP", &createHTTPClass},
+        {"HTTP", &createHTTPModule},
 #endif
         {NULL, NULL}
 };

--- a/c/optionals/path.c
+++ b/c/optionals/path.c
@@ -215,7 +215,8 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     push(vm, OBJ_VAL(dir_contents));
 
     #ifdef _WIN32
-    char *searchPath = ALLOCATE(vm, char, strlen(path) + 4);
+    int length = strlen(path) + 4;
+    char *searchPath = ALLOCATE(vm, char, length);
     if (searchPath == NULL) {
         runtimeError(vm, "Memory error on listdir()!");
         return EMPTY_VAL;
@@ -243,7 +244,7 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     } while (FindNextFile(dir, &file) != 0);
 
     FindClose(dir);
-    FREE_ARRAY(vm, char, searchPath, strlen(path) + 4);
+    FREE_ARRAY(vm, char, searchPath, length);
     #else
     struct dirent *dir;
     DIR *d;

--- a/c/optionals/path.c
+++ b/c/optionals/path.c
@@ -262,10 +262,11 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
         runtimeError(vm, "%s is not a path!", path);
         return EMPTY_VAL;
     }
+
+    closedir(d);
     #endif
 
     pop(vm);
-    closedir(d);
 
     return OBJ_VAL(dir_contents);
 }

--- a/c/optionals/path.c
+++ b/c/optionals/path.c
@@ -269,7 +269,7 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     return OBJ_VAL(dir_contents);
 }
 
-ObjModule *createPathClass(VM *vm) {
+ObjModule *createPathModule(VM *vm) {
     ObjString *name = copyString(vm, "Path", 4);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/path.c
+++ b/c/optionals/path.c
@@ -215,7 +215,7 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     push(vm, OBJ_VAL(dir_contents));
 
     #ifdef _WIN32
-    char *searchPath = malloc(strlen(path) + 4);
+    char *searchPath = ALLOCATE(vm, char, strlen(path) + 4);
     if (searchPath == NULL) {
         runtimeError(vm, "Memory error on listdir()!");
         return EMPTY_VAL;
@@ -243,7 +243,7 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     } while (FindNextFile(dir, &file) != 0);
 
     FindClose(dir);
-    free(searchPath);
+    FREE_ARRAY(vm, char, searchPath, strlen(path) + 4);
     #else
     struct dirent *dir;
     DIR *d;
@@ -265,6 +265,7 @@ static Value listdirNative(VM *vm, int argCount, Value *args) {
     #endif
 
     pop(vm);
+    closedir(d);
 
     return OBJ_VAL(dir_contents);
 }

--- a/c/optionals/path.h
+++ b/c/optionals/path.h
@@ -41,6 +41,6 @@
 #include "../vm.h"
 #include "../memory.h"
 
-ObjModule *createPathClass(VM *vm);
+ObjModule *createPathModule(VM *vm);
 
 #endif //dictu_path_h

--- a/c/optionals/random.c
+++ b/c/optionals/random.c
@@ -67,7 +67,7 @@ static Value randomSelect(VM *vm, int argCount, Value *args)
     return args[index];
 }
 
-ObjModule *createRandomClass(VM *vm)
+ObjModule *createRandomModule(VM *vm)
 {
     ObjString *name = copyString(vm, "Random", 6);
     push(vm, OBJ_VAL(name));

--- a/c/optionals/random.h
+++ b/c/optionals/random.h
@@ -7,6 +7,6 @@
 #include "optionals.h"
 #include "../vm.h"
 
-ObjModule *createRandomClass(VM *vm);
+ObjModule *createRandomModule(VM *vm);
 
 #endif //dictu_random_h

--- a/c/optionals/socket.c
+++ b/c/optionals/socket.c
@@ -223,7 +223,7 @@ static Value setSocketOpt(VM *vm, int argCount, Value *args) {
     return TRUE_VAL;
 }
 
-ObjModule *createSocketClass(VM *vm) {
+ObjModule *createSocketModule(VM *vm) {
     ObjString *name = copyString(vm, "Socket", 6);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/socket.h
+++ b/c/optionals/socket.h
@@ -10,6 +10,6 @@
 #include <netinet/in.h>
 #endif
 
-ObjModule *createSocketClass(VM *vm);
+ObjModule *createSocketModule(VM *vm);
 
 #endif //dictu_socket_h

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -307,7 +307,7 @@ void initPlatform(VM *vm, Table *table) {
 #endif
 }
 
-void createSystemClass(VM *vm, int argc, const char *argv[]) {
+void createSystemModule(VM *vm, int argc, const char *argv[]) {
     ObjString *name = copyString(vm, "System", 6);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/system.h
+++ b/c/optionals/system.h
@@ -24,6 +24,6 @@
 #include "../vm.h"
 #include "../memory.h"
 
-void createSystemClass(VM *vm, int argc, const char *argv[]);
+void createSystemModule(VM *vm, int argc, const char *argv[]);
 
 #endif //dictu_system_h

--- a/c/util.c
+++ b/c/util.c
@@ -3,8 +3,9 @@
 #include <string.h>
 
 #include "vm.h"
+#include "memory.h"
 
-char *readFile(const char *path) {
+char *readFile(VM *vm, const char *path) {
     FILE *file = fopen(path, "rb");
     if (file == NULL) {
         return NULL;
@@ -14,7 +15,7 @@ char *readFile(const char *path) {
     size_t fileSize = ftell(file);
     rewind(file);
 
-    char *buffer = (char *) malloc(fileSize + 1);
+    char *buffer = ALLOCATE(vm, char, fileSize + 1);
     if (buffer == NULL) {
         fprintf(stderr, "Not enough memory to read \"%s\".\n", path);
         exit(74);

--- a/c/util.h
+++ b/c/util.h
@@ -3,7 +3,7 @@
 
 #include "vm.h"
 
-char *readFile(const char *path);
+char *readFile(VM *vm, const char *path);
 
 void defineNative(VM *vm, Table *table, const char *name, NativeFn function);
 

--- a/c/vm.c
+++ b/c/vm.c
@@ -1108,7 +1108,7 @@ static InterpretResult run(VM *vm) {
                 DISPATCH();
             }
 
-            char *source = readFile(fileName->chars);
+            char *source = readFile(vm, fileName->chars);
 
             if (source == NULL) {
                 frame->ip = ip;
@@ -1132,7 +1132,8 @@ static InterpretResult run(VM *vm) {
             push(vm, OBJ_VAL(module));
             ObjFunction *function = compile(vm, module, source);
             pop(vm);
-            free(source);
+
+            FREE_ARRAY(vm, char, source, strlen(source) + 1);
 
             if (function == NULL) return INTERPRET_COMPILE_ERROR;
             push(vm, OBJ_VAL(function));

--- a/c/vm.c
+++ b/c/vm.c
@@ -145,10 +145,10 @@ VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
 
     /**
      * Native classes which are not required to be
-     * imported. For imported natives see optionals.c
+     * imported. For imported modules see optionals.c
      */
-    createSystemClass(vm, argc, argv);
-    createCClass(vm);
+    createSystemModule(vm, argc, argv);
+    createCModule(vm);
 
     return vm;
 }


### PR DESCRIPTION
# Cleanup
Note: There are still a few malloc calls left in (mainly from valueToString), that will be handled by a future PR.
## Summary
This PR does a number of cleanup tasks:
- Built in module creation functions had the older createXClass naming convention, this has been updated to createXModule instead.
- Begin removing calls to malloc / alloc / free throughout the codebase and instead use the defined macros where applicable. This will make it a lot easier to switch out the memory management functions if we ever need to