### PR TITLE
Allow dictu to compile on alpine linux

### DIFF
--- a/c/optionals/datetime.h
+++ b/c/optionals/datetime.h
@@ -1,8 +1,12 @@
 #ifndef dictu_datetime_h
 #define dictu_datetime_h
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
+#endif
+#ifndef __USE_XOPEN
 #define __USE_XOPEN
+#endif
 
 #include <time.h>
 

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -28,7 +28,8 @@ static void createResponse(VM *vm, Response *response) {
     response->res[0] = '\0';
 }
 
-static size_t writeResponse(char *ptr, size_t size, size_t nmemb, Response *response) {
+static size_t writeResponse(char *ptr, size_t size, size_t nmemb, void *data) {
+    Response *response = (Response *) data;
     size_t new_len = response->len + size * nmemb;
     response->res = GROW_ARRAY(response->vm, response->res, char, response->len, new_len + 1);
     if (response->res == NULL) {


### PR DESCRIPTION
# Allow dictu to compile on alpine linux
Resolves #308 
## Summary
This PR adds in some preprocessor conditionals around definitions as it seems they've already been defined in some scenarios while also changing the function header of `writeData` back to what it was.