### PR TITLE
Abstract method error

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -1278,6 +1278,11 @@ static void method(Compiler *compiler) {
         // Setup function and parse parameters
         beginFunction(compiler, &fnCompiler, TYPE_ABSTRACT);
         endCompiler(&fnCompiler);
+
+        if (check(compiler, TOKEN_LEFT_BRACE)) {
+            error(compiler->parser, "Abstract methods can not have an implementation.");
+            return;
+        }
     }
 
     emitBytes(compiler, OP_METHOD, constant);


### PR DESCRIPTION
# Abstract method error
## Summary
Abstract methods are methods defined in abstract classes that have no implementation and **must** be defined in classes which inherit the base class. Currently if a user creates a base class, and does actually provide an implementation in the abstract class, which is not allowed, the error message is a bit confusing (`Error at '{': Expect method name.`). This PR changes the error message to instead be `Error at ')': Abstract methods can not have an implementation.`.