### PR TITLE
Update use of takeString

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -787,8 +787,8 @@ static void string(Compiler *compiler, bool canAssign) {
     int length = parseString(string, parser->previous.length - 2);
     string[length] = '\0';
 
-    emitConstant(compiler, OBJ_VAL(takeString(parser->vm, string, length)));
-    parser->vm->bytesAllocated -= parser->previous.length - 2 - length;
+    emitConstant(compiler, OBJ_VAL(copyString(parser->vm, string, length)));
+    FREE_ARRAY(parser->vm, char, string, parser->previous.length - 1);
 }
 
 static void list(Compiler *compiler, bool canAssign) {

--- a/c/datatypes/files.c
+++ b/c/datatypes/files.c
@@ -85,7 +85,10 @@ static Value readFullFile(VM *vm, int argCount, Value *args) {
     }
 
     buffer[bytesRead] = '\0';
-    return OBJ_VAL(takeString(vm, buffer, bytesRead));
+    Value newString = OBJ_VAL(copyString(vm, buffer, bytesRead));
+    FREE_ARRAY(vm, char, buffer, fileSize + 1);
+
+    return newString;
 }
 
 static Value readLineFile(VM *vm, int argCount, Value *args) {

--- a/c/datatypes/lists.c
+++ b/c/datatypes/lists.c
@@ -263,7 +263,10 @@ static Value joinListItem(VM *vm, int argCount, Value *args) {
         free(output);
     }
 
-    return OBJ_VAL(takeString(vm, fullString, length));
+    Value newString = OBJ_VAL(copyString(vm, fullString, length));
+    FREE_ARRAY(vm, char, fullString, length + 1);
+
+    return newString;
 }
 
 static Value copyListShallow(VM *vm, int argCount, Value *args) {

--- a/c/datatypes/number.c
+++ b/c/datatypes/number.c
@@ -18,7 +18,10 @@ static Value toStringNumber(VM *vm, int argCount, Value *args) {
     }
     
     snprintf(numberString, numberStringLength, "%.15g", number);
-    return OBJ_VAL(takeString(vm, numberString, numberStringLength - 1));
+    Value newString = OBJ_VAL(copyString(vm, numberString, numberStringLength - 1));
+    FREE_ARRAY(vm, char, numberString, numberStringLength);
+
+    return newString;
 }
 
 void declareNumberMethods(VM *vm) {

--- a/c/natives.c
+++ b/c/natives.c
@@ -123,9 +123,10 @@ static Value inputNative(VM *vm, int argCount, Value *args) {
 
     line[length] = '\0';
 
-    Value l = OBJ_VAL(takeString(vm, line, length));
-    vm->bytesAllocated -= currentSize - length - 1;
-    return l;
+    Value newString = OBJ_VAL(copyString(vm, line, length));
+    FREE_ARRAY(vm, char, line, currentSize);
+
+    return newString;
 }
 
 static Value printNative(VM *vm, int argCount, Value *args) {

--- a/c/optionals/datetime.c
+++ b/c/optionals/datetime.c
@@ -120,11 +120,10 @@ static Value strftimeNative(VM *vm, int argCount, Value *args) {
     }
 
     int length = strlen(point);
+    Value newString = OBJ_VAL(copyString(vm, point, length));
+    FREE_ARRAY(vm, char, point, len);
 
-    // Account for the buffer created at the start
-    vm->bytesAllocated -= len - length - 1;
-
-    return OBJ_VAL(takeString(vm, point, length));
+    return newString;
 }
 
 #ifdef HAS_STRPTIME

--- a/c/optionals/http.c
+++ b/c/optionals/http.c
@@ -118,7 +118,8 @@ static char *dictToPostArgs(ObjDict *dict) {
 static ObjDict *endRequest(VM *vm, CURL *curl, Response response) {
     // Get status code
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.statusCode);
-    ObjString *content = takeString(vm, response.res, response.len);
+    ObjString *content = copyString(vm, response.res, response.len);
+    FREE_ARRAY(vm, char, response.res, response.len + 1);
 
     // Push to stack to avoid GC
     push(vm, OBJ_VAL(content));

--- a/c/optionals/json.c
+++ b/c/optionals/json.c
@@ -260,12 +260,8 @@ static Value stringify(VM *vm, int argCount, Value *args) {
     char *buf = ALLOCATE(vm, char, length);
     json_serialize_ex(buf, json, default_opts);
     int actualLength = strlen(buf);
-    ObjString *string = takeString(vm, buf, actualLength);
-
-    // json_measure_ex can produce a length larger than the actual string returned
-    // so we need to cater for this case
-    vm->bytesAllocated -= length - actualLength - 1;
-
+    ObjString *string = copyString(vm, buf, actualLength);
+    FREE_ARRAY(vm, char, buf, length);
     json_builder_free(json);
     return OBJ_VAL(string);
 }


### PR DESCRIPTION
# Update use of takeString
## Summary
Recently there was an update where many calls to `copyString` were changed to `takeString` which on the surface made sense, however on further thinking, it wasn't right. If we used takeString and a given string was already interned then you would be left with allocated memory hanging around (since the GC would not clean allocated char pointers). This PR changes this to go back to using copyString and properly cleaning the allocated strings.