### PR TITLE
__file__

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -22,7 +22,7 @@ static void errorAt(Parser *parser, Token *token, const char *message) {
     if (parser->panicMode) return;
     parser->panicMode = true;
 
-    fprintf(stderr, "[%s line %d] Error", parser->vm->scriptNames[parser->vm->scriptNameCount], token->line);
+    fprintf(stderr, "[%s line %d] Error", parser->module->name->chars, token->line);
 
     if (token->type == TOKEN_EOF) {
         fprintf(stderr, " at end");

--- a/c/main.c
+++ b/c/main.c
@@ -73,7 +73,7 @@ static bool replCountQuotes(char *line) {
 }
 #endif
 
-static void repl(VM *vm, int argc, const char *argv[]) {
+static void repl(VM *vm, int argc, char *argv[]) {
     UNUSED(argc); UNUSED(argv);
 
     printf(VERSION);
@@ -115,7 +115,7 @@ static void repl(VM *vm, int argc, const char *argv[]) {
             linenoiseHistorySave("history.txt");
         }
 
-        interpret(vm, fullLine);
+        interpret(vm, "repl", fullLine);
 
         free(line);
         FREE_ARRAY(vm, char, fullLine, fullLineLength + 1);
@@ -150,7 +150,7 @@ static void repl(VM *vm, int argc, const char *argv[]) {
             }
         }
 
-        interpret(vm, line);
+        interpret(vm, "repl", line);
         lineLength = 0;
         line[0] = '\0';
     }
@@ -160,7 +160,7 @@ static void repl(VM *vm, int argc, const char *argv[]) {
     #endif
 }
 
-static void runFile(VM *vm, int argc, const char *argv[]) {
+static void runFile(VM *vm, int argc, char *argv[]) {
     UNUSED(argc);
 
     char *source = readFile(vm, argv[1]);
@@ -170,14 +170,14 @@ static void runFile(VM *vm, int argc, const char *argv[]) {
         exit(74);
     }
 
-    InterpretResult result = interpret(vm, source);
+    InterpretResult result = interpret(vm, argv[1], source);
     FREE_ARRAY(vm, char, source, strlen(source) + 1);
 
     if (result == INTERPRET_COMPILE_ERROR) exit(65);
     if (result == INTERPRET_RUNTIME_ERROR) exit(70);
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, char *argv[]) {
     #ifdef _WIN32
     atexit(cleanupSockets);
     WORD versionWanted = MAKEWORD(2, 2);
@@ -185,7 +185,7 @@ int main(int argc, const char *argv[]) {
     WSAStartup(versionWanted, &wsaData);
     #endif
 
-    VM *vm = initVM(argc == 1, argc >= 2 ? argv[1] : "repl", argc, argv);
+    VM *vm = initVM(argc == 1, argc, argv);
 
     if (argc == 1) {
         repl(vm, argc, argv);

--- a/c/object.c
+++ b/c/object.c
@@ -37,7 +37,13 @@ ObjModule *newModule(VM *vm, ObjString *name) {
     module->name = name;
 
     push(vm, OBJ_VAL(module));
+    ObjString *__file__ = copyString(vm, "__file__", 8);
+    push(vm, OBJ_VAL(__file__));
+
+    tableSet(vm, &module->values, __file__, OBJ_VAL(name));
     tableSet(vm, &vm->modules, name, OBJ_VAL(module));
+
+    pop(vm);
     pop(vm);
 
     return module;

--- a/c/optionals/system.c
+++ b/c/optionals/system.c
@@ -275,7 +275,7 @@ static Value exitNative(VM *vm, int argCount, Value *args) {
     return EMPTY_VAL; /* satisfy the tcc compiler */
 }
 
-void initArgv(VM *vm, Table *table, int argc, const char *argv[]) {
+void initArgv(VM *vm, Table *table, int argc, char *argv[]) {
     ObjList *list = initList(vm);
     push(vm, OBJ_VAL(list));
 
@@ -307,7 +307,7 @@ void initPlatform(VM *vm, Table *table) {
 #endif
 }
 
-void createSystemModule(VM *vm, int argc, const char *argv[]) {
+void createSystemModule(VM *vm, int argc, char *argv[]) {
     ObjString *name = copyString(vm, "System", 6);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);

--- a/c/optionals/system.h
+++ b/c/optionals/system.h
@@ -24,6 +24,6 @@
 #include "../vm.h"
 #include "../memory.h"
 
-void createSystemModule(VM *vm, int argc, const char *argv[]);
+void createSystemModule(VM *vm, int argc, char *argv[]);
 
 #endif //dictu_system_h

--- a/c/vm.c
+++ b/c/vm.c
@@ -44,10 +44,10 @@ void runtimeError(VM *vm, const char *format, ...) {
                 function->chunk.lines[instruction]);
 
         if (function->name == NULL) {
-            fprintf(stderr, "%s: ", vm->scriptNames[vm->scriptNameCount]);
+            fprintf(stderr, "%s: ", function->module->name->chars);
             i = -1;
         } else {
-            fprintf(stderr, "%s(): ", function->name->chars);
+            fprintf(stderr, "%s() [%s]: ", function->name->chars, function->module->name->chars);
         }
 
         va_list args;
@@ -60,24 +60,7 @@ void runtimeError(VM *vm, const char *format, ...) {
     resetStack(vm);
 }
 
-void setupFilenameStack(VM *vm, const char *scriptName) {
-    vm->scriptNameCapacity = 8;
-    vm->scriptNames = ALLOCATE(vm, const char*, vm->scriptNameCapacity);
-    vm->scriptNameCount = 0;
-    vm->scriptNames[vm->scriptNameCount] = scriptName;
-}
-
-void setcurrentFile(VM *vm, const char *scriptname, int len) {
-    ObjString *name = copyString(vm, scriptname, len);
-    push(vm, OBJ_VAL(name));
-    ObjString *__file__ = copyString(vm, "__file__", 8);
-    push(vm, OBJ_VAL(__file__));
-    tableSet(vm, &vm->globals, __file__, OBJ_VAL(name));
-    pop(vm);
-    pop(vm);
-}
-
-VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
+VM *initVM(bool repl, int argc, char *argv[]) {
     VM *vm = malloc(sizeof(*vm));
 
     if (vm == NULL) {
@@ -116,13 +99,6 @@ VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]) {
     initTable(&vm->classMethods);
     initTable(&vm->instanceMethods);
     initTable(&vm->socketMethods);
-
-    setupFilenameStack(vm, scriptName);
-    if (scriptName == NULL) {
-        setcurrentFile(vm, "", 0);
-    } else {
-        setcurrentFile(vm, scriptName, (int) strlen(scriptName));
-    }
 
     vm->frames = ALLOCATE(vm, CallFrame, vm->frameCapacity);
     vm->initString = copyString(vm, "init", 4);
@@ -170,7 +146,6 @@ void freeVM(VM *vm) {
     freeTable(vm, &vm->instanceMethods);
     freeTable(vm, &vm->socketMethods);
     FREE_ARRAY(vm, CallFrame, vm->frames, vm->frameCapacity);
-    FREE_ARRAY(vm, const char*, (char**)vm->scriptNames, vm->scriptNameCapacity);
     vm->initString = NULL;
     vm->replVar = NULL;
     freeObjects(vm);
@@ -1102,7 +1077,6 @@ static InterpretResult run(VM *vm) {
 
             // If we have imported this file already, skip.
             if (tableGet(&vm->modules, fileName, &moduleVal)) {
-                ++vm->scriptNameCount;
                 vm->lastModule = AS_MODULE(moduleVal);
                 push(vm, NIL_VAL);
                 DISPATCH();
@@ -1115,16 +1089,6 @@ static InterpretResult run(VM *vm) {
                 runtimeError(vm, "Could not open file \"%s\".", fileName->chars);
                 return INTERPRET_RUNTIME_ERROR;
             }
-
-            if (vm->scriptNameCapacity < vm->scriptNameCount + 2) {
-                int oldCapacity = vm->scriptNameCapacity;
-                vm->scriptNameCapacity = GROW_CAPACITY(oldCapacity);
-                vm->scriptNames = GROW_ARRAY(vm, (char**)vm->scriptNames, const char*,
-                                           oldCapacity, vm->scriptNameCapacity);
-            }
-
-            vm->scriptNames[++vm->scriptNameCount] = fileName->chars;
-            setcurrentFile(vm, fileName->chars, fileName->length);
 
             ObjModule *module = newModule(vm, fileName);
             vm->lastModule = module;
@@ -1156,14 +1120,12 @@ static InterpretResult run(VM *vm) {
 
             // If we have imported this module already, skip.
             if (tableGet(&vm->modules, fileName, &moduleVal)) {
-                ++vm->scriptNameCount;
                 push(vm, moduleVal);
                 DISPATCH();
             }
 
             ObjModule *module = importBuiltinModule(vm, index);
 
-            ++vm->scriptNameCount;
             push(vm, OBJ_VAL(module));
             DISPATCH();
         }
@@ -1211,7 +1173,6 @@ static InterpretResult run(VM *vm) {
                 ObjString *variable = READ_STRING();
 
                 if (!tableGet(&vm->lastModule->values, variable, &moduleVariable)) {
-                    vm->scriptNameCount--;
                     frame->ip = ip;
                     runtimeError(vm, "%s can't be found in module %s", variable->chars, vm->lastModule->name->chars);
                     return INTERPRET_RUNTIME_ERROR;
@@ -1224,16 +1185,7 @@ static InterpretResult run(VM *vm) {
         }
 
         CASE_CODE(IMPORT_END): {
-            vm->scriptNameCount--;
-            if (vm->scriptNameCount >= 0) {
-                setcurrentFile(vm, vm->scriptNames[vm->scriptNameCount],
-                     (int) strlen(vm->scriptNames[vm->scriptNameCount]));
-            } else {
-                setcurrentFile(vm, "", 0);
-            }
-
             vm->lastModule = frame->closure->function->module;
-
             DISPATCH();
         }
 
@@ -1828,8 +1780,8 @@ static InterpretResult run(VM *vm) {
 
 }
 
-InterpretResult interpret(VM *vm, const char *source) {
-    ObjString *name = copyString(vm, "main", 4);
+InterpretResult interpret(VM *vm, char *moduleName, char *source) {
+    ObjString *name = copyString(vm, moduleName, strlen(moduleName));
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);
     pop(vm);

--- a/c/vm.h
+++ b/c/vm.h
@@ -20,9 +20,6 @@ struct _vm {
     Value stack[STACK_MAX];
     Value *stackTop;
     bool repl;
-    const char **scriptNames;
-    int scriptNameCount;
-    int scriptNameCapacity;
     CallFrame *frames;
     int frameCount;
     int frameCapacity;
@@ -64,11 +61,11 @@ typedef enum {
 #define OK     0
 #define NOTOK -1
 
-VM *initVM(bool repl, const char *scriptName, int argc, const char *argv[]);
+VM *initVM(bool repl, int argc, char *argv[]);
 
 void freeVM(VM *vm);
 
-InterpretResult interpret(VM *vm, const char *source);
+InterpretResult interpret(VM *vm, char *moduleName, char *source);
 
 void push(VM *vm, Value value);
 

--- a/docs/docs/modules.md
+++ b/docs/docs/modules.md
@@ -91,3 +91,12 @@ from "some/file.du" import x, test;
 print(x); // 10
 print(test()); // "test"
 ```
+
+#### \__file__
+
+Similar to the built-in variable, `__file__` is also available on built-in modules.
+
+```
+import HTTP;
+print(HTTP.__file__); // 'HTTP'
+```  


### PR DESCRIPTION
# \_\_file__
## Summary
The `__file__` variable was not working correctly in imported modules unless it was in the global scope, so for example, an imported module that used this variable within a function would have it set to the parent modules file path, which shouldn't be the case. This PR changes this so `__file__` is now an attribute on the module instead of tracking filenames through the VM.