### PR TITLE
Ensure inet_ntop is included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ docs/_site/
 cmake-build-debug/
 
 cmake-build-release/
+
+.vs/
+
+dictu.exe
+
+dictu.exe.manifest

--- a/src/optionals/windowsapi.h
+++ b/src/optionals/windowsapi.h
@@ -4,6 +4,11 @@
 // Window's TokenType is documented here: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class
 #ifdef _WIN32
 #define TokenType WinntTokenType
+// Work around to ensure inet_ntop is included (comes from Vista+)
+#if (_WIN32_WINNT < 0x0600)
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #undef TokenType


### PR DESCRIPTION
# Sockets
## Summary
When attempting to build Dictu on windows 8 with CLion and mingw-w64 the value for `_WIN32_WINNT` was `0x502` which corresponds to windows server 2003. `inet_ntop` was added as part of Windows Vista, so to work around this faulty value we ensure the macros value is set to at least `0x0600` which corresponds to Windows Vista.