### PR TITLE
Internal abstract type

### DIFF
--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -151,7 +151,12 @@ static void blackenObject(DictuVM *vm, Obj *object) {
             break;
         }
 
-        case OBJ_SOCKET:
+        case OBJ_ABSTRACT: {
+            ObjAbstract *abstract = (ObjAbstract *) object;
+            grayTable(vm, &abstract->values);
+            break;
+        }
+
         case OBJ_NATIVE:
         case OBJ_STRING:
         case OBJ_FILE:
@@ -254,8 +259,11 @@ void freeObject(DictuVM *vm, Obj *object) {
             break;
         }
 
-        case OBJ_SOCKET: {
-            FREE(vm, ObjSocket, object);
+        case OBJ_ABSTRACT: {
+            ObjAbstract *abstract = (ObjAbstract*) object;
+            abstract->func(vm, abstract);
+            freeTable(vm, &abstract->values);
+            FREE(vm, ObjAbstract, object);
             break;
         }
     }

--- a/src/vm/natives.c
+++ b/src/vm/natives.c
@@ -58,8 +58,6 @@ static Value typeNative(DictuVM *vm, int argCount, Value *args) {
                 return OBJ_VAL(copyString(vm, "native", 6));
             case OBJ_FILE:
                 return OBJ_VAL(copyString(vm, "file", 4));
-            case OBJ_SOCKET:
-                return OBJ_VAL(copyString(vm, "socket", 6));
             default:
                 break;
         }

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -146,8 +146,16 @@ ObjSet *initSet(DictuVM *vm) {
 }
 
 ObjFile *initFile(DictuVM *vm) {
-    ObjFile *file = ALLOCATE_OBJ(vm, ObjFile, OBJ_FILE);
-    return file;
+    return ALLOCATE_OBJ(vm, ObjFile, OBJ_FILE);
+}
+
+ObjAbstract *initAbstract(DictuVM *vm, AbstractFreeFn func) {
+    ObjAbstract *abstract = ALLOCATE_OBJ(vm, ObjAbstract, OBJ_ABSTRACT);
+    abstract->data = NULL;
+    abstract->func = func;
+    initTable(&abstract->values);
+
+    return abstract;
 }
 
 static uint32_t hashString(const char *key, int length) {
@@ -192,16 +200,6 @@ ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot) {
     upvalue->next = NULL;
 
     return upvalue;
-}
-
-ObjSocket *newSocket(DictuVM *vm, int sock, int socketFamily, int socketType, int socketProtocol) {
-    ObjSocket *socket = ALLOCATE_OBJ(vm, ObjSocket, OBJ_SOCKET);
-    socket->socket = sock;
-    socket->socketFamily = socketFamily;
-    socket->socketType = socketType;
-    socket->socketProtocol = socketProtocol;
-
-    return socket;
 }
 
 char *listToString(Value value) {
@@ -598,11 +596,9 @@ char *objectToString(Value value) {
             return upvalueString;
         }
 
-        case OBJ_SOCKET: {
-            char *socketString = malloc(sizeof(char) * 7);
-            memcpy(socketString, "socket", 6);
-            socketString[6] = '\0';
-            return socketString;
+        // TODO: Think about string conversion for abstract types
+        case OBJ_ABSTRACT: {
+            break;
         }
     }
 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -25,7 +25,7 @@
 #define AS_DICT(value)          ((ObjDict*)AS_OBJ(value))
 #define AS_SET(value)           ((ObjSet*)AS_OBJ(value))
 #define AS_FILE(value)          ((ObjFile*)AS_OBJ(value))
-#define AS_SOCKET(value)        ((ObjSocket*)AS_OBJ(value))
+#define AS_ABSTRACT(value)      ((ObjAbstract*)AS_OBJ(value))
 
 #define IS_MODULE(value)          isObjType(value, OBJ_MODULE)
 #define IS_BOUND_METHOD(value)    isObjType(value, OBJ_BOUND_METHOD)
@@ -41,7 +41,7 @@
 #define IS_DICT(value)            isObjType(value, OBJ_DICT)
 #define IS_SET(value)             isObjType(value, OBJ_SET)
 #define IS_FILE(value)            isObjType(value, OBJ_FILE)
-#define IS_SOCKET(value)        isObjType(value, OBJ_SOCKET)
+#define IS_ABSTRACT(value)        isObjType(value, OBJ_ABSTRACT)
 
 typedef enum {
     OBJ_MODULE,
@@ -56,7 +56,7 @@ typedef enum {
     OBJ_DICT,
     OBJ_SET,
     OBJ_FILE,
-    OBJ_SOCKET,
+    OBJ_ABSTRACT,
     OBJ_UPVALUE
 } ObjType;
 
@@ -153,6 +153,15 @@ struct sObjFile {
     char *openType;
 };
 
+typedef void (*AbstractFreeFn)(DictuVM *vm, ObjAbstract *abstract);
+
+struct sObjAbstract {
+    Obj obj;
+    Table values;
+    void *data;
+    AbstractFreeFn func;
+};
+
 typedef struct sUpvalue {
     Obj obj;
 
@@ -199,14 +208,6 @@ typedef struct {
     ObjClosure *method;
 } ObjBoundMethod;
 
-typedef struct {
-    Obj obj;
-    int socket;
-    int socketFamily;    /* Address family, e.g., AF_INET */
-    int socketType;      /* Socket type, e.g., SOCK_STREAM */
-    int socketProtocol;  /* Protocol type, usually 0 */
-} ObjSocket;
-
 ObjModule *newModule(DictuVM *vm, ObjString *name);
 
 ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method);
@@ -233,7 +234,7 @@ ObjSet *initSet(DictuVM *vm);
 
 ObjFile *initFile(DictuVM *vm);
 
-ObjSocket *newSocket(DictuVM *vm, int sock, int socketFamily, int socketType, int socketProtocol);
+ObjAbstract *initAbstract(DictuVM *vm, AbstractFreeFn func);
 
 ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot);
 

--- a/src/vm/value.h
+++ b/src/vm/value.h
@@ -10,6 +10,7 @@ typedef struct sObjList ObjList;
 typedef struct sObjDict ObjDict;
 typedef struct sObjSet  ObjSet;
 typedef struct sObjFile ObjFile;
+typedef struct sObjAbstract ObjAbstract;
 
 #ifdef NAN_TAGGING
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -429,10 +429,11 @@ static bool invoke(DictuVM *vm, ObjString *name, int argCount) {
                 return false;
             }
 
-            // TODO: Think of a way to handle this for imported classes
-            case OBJ_SOCKET: {
+            case OBJ_ABSTRACT: {
+                ObjAbstract *abstract = AS_ABSTRACT(receiver);
+
                 Value value;
-                if (tableGet(&vm->socketMethods, name, &value)) {
+                if (tableGet(&abstract->values, name, &value)) {
                     return callNativeMethod(vm, value, argCount);
                 }
 

--- a/tests/sockets/bind.du
+++ b/tests/sockets/bind.du
@@ -10,7 +10,6 @@ import Socket;
 var socket = Socket.create(Socket.AF_INET, Socket.SOCK_STREAM);
 
 assert(socket != nil);
-assert(type(socket) == "socket");
 
 assert(socket.bind("127.0.0.1", 8080) == true);
 assert(socket.bind("aaa", 8080) == nil);

--- a/tests/sockets/create.du
+++ b/tests/sockets/create.du
@@ -10,7 +10,6 @@ import Socket;
 var socket = Socket.create(Socket.AF_INET, Socket.SOCK_STREAM);
 
 assert(socket != nil);
-assert(type(socket) == "socket");
 
 socket.close();
 

--- a/tests/sockets/setsockopt.du
+++ b/tests/sockets/setsockopt.du
@@ -10,8 +10,6 @@ import Socket;
 var socket = Socket.create(Socket.AF_INET, Socket.SOCK_STREAM);
 
 assert(socket != nil);
-assert(type(socket) == "socket");
-
 assert(socket.setsockopt(Socket.SOL_SOCKET, Socket.SO_REUSEADDR) == true);
 
 socket.close();


### PR DESCRIPTION
# Internal abstract type
## Summary
This adds a new type of object to the internals of Dictu, `OBJ_ABSTRACT`. What this is, is essentially a wrapper for any type of data that a C extension could possibly need (for example the socket library needs a struct of data to store information about socket data). The benefit of this type is it allows a much easier interface when creating C extensions as the new type does not need to be added throughout the internals of the VM and instead everything can be encapsulated within the additional files!

## GC
The GC will handle freeing the majority of the abstract object, however all user created mallocs within the given extension must be free'd, to do this is quite simple.

When we create the new abstract object it expects two parameters, the VM, and a function pointer
```c
typedef void (*AbstractFreeFn)(DictuVM *vm, ObjAbstract *abstract);
```
When the GC is ready to cleanup the abstract type, this function will be automatically be called for you.
### Example
```c
void freeSocket(DictuVM *vm, ObjAbstract *abstract) {
    FREE(vm, SocketData, abstract->data);
}
```

### Note
This PR does not include a method for attempting to convert an "abstract" to a string, so if it's attempted to be converted it will be "unknown".