### PR TITLE
Fix an issue with constant folding

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -545,7 +545,7 @@ static void binary(Compiler *compiler, Token previousToken, bool canAssign) {
     TokenType currentToken = compiler->parser->previous.type;
 
     // Attempt constant fold.
-    if ((previousToken.type == TOKEN_NUMBER || previousToken.type == TOKEN_RIGHT_PAREN) &&
+    if ((previousToken.type == TOKEN_NUMBER) &&
         (currentToken == TOKEN_NUMBER || currentToken == TOKEN_LEFT_PAREN) &&
         foldBinary(compiler, operatorType)
             ) {

--- a/tests/operators/plus.du
+++ b/tests/operators/plus.du
@@ -10,3 +10,31 @@ assert(x + 1 == 11);
 assert(x + x == 20);
 assert(1 + x == 11);
 assert(10 + x + 10 == 30);
+
+// Test function call (useful for constant folding)
+def test() {
+    return 1 + 2 + 3;
+}
+
+assert(test() + 2 + test() == 14);
+
+def calculate(a, b, c) {
+    return a + b + c;
+}
+
+assert(calculate(1, 2, 3) + calculate(2, 3, 4) == 15);
+
+// Test super
+class Test {
+    test() {
+        return 10;
+    }
+}
+
+class AnotherClass < Test {
+    test() {
+        return super.test() + 10;
+    }
+}
+
+assert(AnotherClass().test() == 20);


### PR DESCRIPTION
# Constant folding
## Summary
This PR fixes an issue with constant folding where it was wrongly attempting to fold a method call when the left operand was a call to a superclass method.