### PR TITLE
Dictionary Subscription

### DIFF
--- a/docs/docs/collections/dictionaries.md
+++ b/docs/docs/collections/dictionaries.md
@@ -26,7 +26,7 @@ var myDict = {"key": 1, "key1": true};
 ### Indexing
 
 Accessing dictionary items is the same syntax as lists, except instead of an index, it expects an immutable type (nil, boolean, number, string) for it's key.
-If you try to access a key that does not exist, `nil` is returned. If you expect a key may not exist `.get()` can be used to return a default value.
+If you try to access a key that does not exist, a runtime error will be raised. If you expect a key may not exist `.get()` can be used to return a default value.
 
 ```cs
 var myDict = {"key": 1, "key1": true};

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1321,11 +1321,10 @@ static DictuInterpretResult run(DictuVM *vm) {
                     pop(vm);
                     if (dictGet(dict, indexValue, &v)) {
                         push(vm, v);
-                    } else {
-                        push(vm, NIL_VAL);
+                        DISPATCH();
                     }
 
-                    DISPATCH();
+                    RUNTIME_ERROR("Key %s does not exist within dictionary.", valueToString(indexValue));
                 }
 
                 default: {
@@ -1514,7 +1513,7 @@ static DictuInterpretResult run(DictuVM *vm) {
 
                     Value dictValue;
                     if (!dictGet(dict, indexValue, &dictValue)) {
-                        dictValue = NIL_VAL;
+                        RUNTIME_ERROR("Key %s does not exist within dictionary.", valueToString(indexValue));
                     }
 
                     vm->stackTop[-1] = dictValue;

--- a/tests/dicts/subscript.du
+++ b/tests/dicts/subscript.du
@@ -12,9 +12,6 @@ assert(myDict == {"key": 1, "key1": true});
 assert(myDict["key"] == 1);
 assert(myDict["key1"]);
 
-// Keys not found return should nil
-assert(myDict["unknown"] == nil);
-
 // Keys not found in assignment should create a new pair
 myDict["test"] = 10;
 assert(myDict == {"key": 1, "key1": true, "test": 10});


### PR DESCRIPTION
# Dictionary Subscription
Resolves #343 
## Summary
This PR changes dictionary subscription behaviour. Currently if you subscript on a dictionary and the key is not present `nil` would be returned. This PR changes this so instead a runtime error occurs. The reasoning behind this change is it makes the code a lot more explicit in an erroneous situation rather than attempting to carry on with a `nil` value. It should also prod the programming to handle a `nil` case more often.