### PR TITLE
Socket connect

### DIFF
--- a/docs/docs/standard-lib/sockets.md
+++ b/docs/docs/standard-lib/sockets.md
@@ -48,7 +48,20 @@ This will bind a given socket object to an IP and port number.
 Returns a Result type and on success will unwrap to nil.
 
 ```cs
-var result = socket.bind("host", 10);
+var result = socket.bind("127.0.0.1", 1000);
+if (!result.success()) {
+    print(result.unwrapError());
+    // ...
+}
+```
+
+### socket.connect(string, number)
+
+This will connect to a socket on a given host and IP.
+Returns a Result type and on success will unwrap to nil.
+
+```cs
+var result = socket.connect("127.0.0.1", 1000);
 if (!result.success()) {
     print(result.unwrapError());
     // ...

--- a/docs/docs/standard-lib/sockets.md
+++ b/docs/docs/standard-lib/sockets.md
@@ -39,7 +39,13 @@ Create a new socket object given a socket type and socket family.
 This will return a Result and unwrap to a new socket object in which the rest of the methods are ran on.
 
 ```cs
-var socket = Socket.create(Socket.AF_INET, Sockket.SOCK_STREAM).unwrap();
+var result = Socket.create(Socket.AF_INET, Socket.SOCK_STREAM);
+if (!result.success()) {
+    print(result.unwrapError());
+    // ...
+}
+
+var socket = result.unwrap();
 ```
 
 ### socket.bind(string, number)

--- a/src/optionals/socket.c
+++ b/src/optionals/socket.c
@@ -197,7 +197,7 @@ static Value recvSocket(DictuVM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
-    char *buffer = ALLOCATE(vm, char, bufferSize);
+    char *buffer = ALLOCATE(vm, char, bufferSize + 1);
     int readSize = recv(sock->socket, buffer, bufferSize, 0);
 
     if (readSize == -1) {

--- a/src/optionals/socket.c
+++ b/src/optionals/socket.c
@@ -190,15 +190,15 @@ static Value recvSocket(DictuVM *vm, int argCount, Value *args) {
     }
 
     SocketData *sock = AS_SOCKET(args[0]);
-    int bufferSize = AS_NUMBER(args[1]);
+    int bufferSize = AS_NUMBER(args[1]) + 1;
 
     if (bufferSize < 1) {
         runtimeError(vm, "recv() argument must be greater than 1");
         return EMPTY_VAL;
     }
 
-    char *buffer = ALLOCATE(vm, char, bufferSize + 1);
-    int readSize = recv(sock->socket, buffer, bufferSize, 0);
+    char *buffer = ALLOCATE(vm, char, bufferSize);
+    int readSize = recv(sock->socket, buffer, bufferSize - 1, 0);
 
     if (readSize == -1) {
         FREE_ARRAY(vm, char, buffer, bufferSize);

--- a/src/optionals/socket.c
+++ b/src/optionals/socket.c
@@ -205,13 +205,49 @@ static Value recvSocket(DictuVM *vm, int argCount, Value *args) {
         ERROR_RESULT;
     }
 
+    // Resize string
+    if (readSize != bufferSize) {
+        buffer = SHRINK_ARRAY(vm, buffer, char, bufferSize, readSize + 1);
+    }
+
+    buffer[readSize] = '\0';
     ObjString *rString = takeString(vm, buffer, readSize);
 
     return newResultSuccess(vm, OBJ_VAL(rString));
 }
 
+static Value connectSocket(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 2) {
+        runtimeError(vm, "connect() takes two arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    if (!IS_STRING(args[1])) {
+        runtimeError(vm, "host passed to bind() must be a string");
+        return EMPTY_VAL;
+    }
+
+    if (!IS_NUMBER(args[2])) {
+        runtimeError(vm, "port passed to bind() must be a number");
+        return EMPTY_VAL;
+    }
+
+    SocketData *sock = AS_SOCKET(args[0]);
+
+    struct sockaddr_in server;
+
+    server.sin_family = sock->socketFamily;
+    server.sin_addr.s_addr = inet_addr(AS_CSTRING(args[1]));
+    server.sin_port = htons(AS_NUMBER(args[2]));
+
+    if (connect(sock->socket, (struct sockaddr *)&server, sizeof(server)) < 0) {
+        ERROR_RESULT;
+    }
+
+    return newResultSuccess(vm, NIL_VAL);
+}
+
 static Value closeSocket(DictuVM *vm, int argCount, Value *args) {
-    UNUSED(vm);
     if (argCount != 0) {
         runtimeError(vm, "close() takes no arguments (%d given)", argCount);
         return EMPTY_VAL;
@@ -269,6 +305,7 @@ ObjAbstract *newSocket(DictuVM *vm, int sock, int socketFamily, int socketType, 
     defineNative(vm, &abstract->values, "accept", acceptSocket);
     defineNative(vm, &abstract->values, "write", writeSocket);
     defineNative(vm, &abstract->values, "recv", recvSocket);
+    defineNative(vm, &abstract->values, "connect", connectSocket);
     defineNative(vm, &abstract->values, "close", closeSocket);
     defineNative(vm, &abstract->values, "setsockopt", setSocketOpt);
     pop(vm);

--- a/src/vm/util.c
+++ b/src/vm/util.c
@@ -72,8 +72,11 @@ ObjString *dirname(DictuVM *vm, char *path, int len) {
 
 bool resolvePath(char *directory, char *path, char *ret) {
     char buf[PATH_MAX];
+    if (*path == DIR_SEPARATOR)
+        snprintf (buf, PATH_MAX, "%s", path);
+    else
+        snprintf(buf, PATH_MAX, "%s%c%s", directory, DIR_SEPARATOR, path);
 
-    snprintf(buf, PATH_MAX, "%s%c%s", directory, DIR_SEPARATOR, path);
 #ifdef _WIN32
     _fullpath(ret, buf, PATH_MAX);
 #else


### PR DESCRIPTION
# Socket connect
## Summary
This PR adds a new `socket.connect` method, along with some bug fixes. Previously there was no way to connect to a socket, only bind to an address, this PR changes this.

This PR also includes bugfixes for `socket.recv` where the total memory was incorrectly being reported, and a bugfix for resolvePath (Thanks @agathoklisx).