### PR TITLE
List.join()

### DIFF
--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -138,13 +138,15 @@ myList.contains(10); // false
 ### list.join(string: delimiter -> optional)
 
 To convert a list of elements to a string use `.join()` to concatenate elements together by a given delimiter.
-If a delimiter is not supplied `", "` is the default.
+If a delimiter is not supplied `", "` is the default. Attempting to join an empty list will return an empty string.
 
 ```cs
 var myList = [1, 2, 3];
 print(myList.join()); // "1, 2, 3"
 print(myList.join("")); // "123"
 print(myList.join("-")); // "1-2-3"
+
+print([].join("delimiter")); // ""
 ```
 
 ### list.remove(value)

--- a/src/vm/datatypes/lists/lists.c
+++ b/src/vm/datatypes/lists/lists.c
@@ -220,6 +220,11 @@ static Value joinListItem(DictuVM *vm, int argCount, Value *args) {
     }
 
     ObjList *list = AS_LIST(args[0]);
+
+    if (list->values.count == 0) {
+        return OBJ_VAL(copyString(vm, "", 0));
+    }
+
     char *delimiter = ", ";
 
     if (argCount == 1) {

--- a/tests/lists/join.du
+++ b/tests/lists/join.du
@@ -6,6 +6,8 @@
  * .join() will return a string of joined list elements by a given delimiter
  */
 
+assert([].join() == "");
+
 var x = [1, 2, 3, 4, 5, 6];
 
 assert(x.join() == "1, 2, 3, 4, 5, 6");


### PR DESCRIPTION
# List.join()
## Summary
This PR fixes an issue where attempting to use `list.join()` on an empty list would produce a segfault. This PR handles this correctly, and instead will return an empty string when using `.join()` on an empty list.