### PR TITLE
Correctly track sqlite database status

### DIFF
--- a/tests/sqlite/create.du
+++ b/tests/sqlite/create.du
@@ -20,3 +20,7 @@ assert(resp.success() == false);
 assert(resp.unwrapError() == "table test already exists");
 
 connection.close();
+
+// Assert operations on a closed connection fail correctly
+assert(connection.execute("CREATE TABLE test1 (x int)").success() == false);
+assert(connection.execute("CREATE TABLE test1 (x int)").unwrapError() == "Database connection is closed");


### PR DESCRIPTION
# Sqlite
## Summary
Previously when a SQLite connection was being cleaned up by the garbage collector, or if `.close()` was called multiple times `sqlite_close()` was being ran regardless of whether or not a previous connection had already been free'd. This PR changes this by tracking the open status of the SQLite object.