### PR TITLE
Argument parsing

### DIFF
--- a/src/cli/argparse.c
+++ b/src/cli/argparse.c
@@ -1,0 +1,384 @@
+/**
+ * Copyright (C) 2012-2015 Yecheng Fu <cofyc.jackson at gmail dot com>
+ * All rights reserved.
+ *
+ * Use of this source code is governed by a MIT-style license that can be found
+ * in the LICENSE file.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include "argparse.h"
+
+#define OPT_UNSET 1
+#define OPT_LONG  (1 << 1)
+
+static const char *
+prefix_skip(const char *str, const char *prefix)
+{
+    size_t len = strlen(prefix);
+    return strncmp(str, prefix, len) ? NULL : str + len;
+}
+
+static int
+prefix_cmp(const char *str, const char *prefix)
+{
+    for (;; str++, prefix++)
+        if (!*prefix) {
+            return 0;
+        } else if (*str != *prefix) {
+            return (unsigned char)*prefix - (unsigned char)*str;
+        }
+}
+
+static void
+argparse_error(struct argparse *self, const struct argparse_option *opt,
+               const char *reason, int flags)
+{
+    (void)self;
+    if (flags & OPT_LONG) {
+        fprintf(stderr, "error: option `--%s` %s\n", opt->long_name, reason);
+    } else {
+        fprintf(stderr, "error: option `-%c` %s\n", opt->short_name, reason);
+    }
+    exit(1);
+}
+
+static int
+argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
+                  int flags)
+{
+    const char *s = NULL;
+    if (!opt->value)
+        goto skipped;
+    switch (opt->type) {
+        case ARGPARSE_OPT_BOOLEAN:
+            if (flags & OPT_UNSET) {
+                *(int *)opt->value = *(int *)opt->value - 1;
+            } else {
+                *(int *)opt->value = *(int *)opt->value + 1;
+            }
+            if (*(int *)opt->value < 0) {
+                *(int *)opt->value = 0;
+            }
+            break;
+        case ARGPARSE_OPT_BIT:
+            if (flags & OPT_UNSET) {
+                *(int *)opt->value &= ~opt->data;
+            } else {
+                *(int *)opt->value |= opt->data;
+            }
+            break;
+        case ARGPARSE_OPT_STRING:
+            if (self->optvalue) {
+                *(const char **)opt->value = self->optvalue;
+                self->optvalue             = NULL;
+            } else if (self->argc > 1) {
+                self->argc--;
+                *(const char **)opt->value = *++self->argv;
+            } else {
+                argparse_error(self, opt, "requires a value", flags);
+            }
+            break;
+        case ARGPARSE_OPT_INTEGER:
+            errno = 0;
+            if (self->optvalue) {
+                *(int *)opt->value = strtol(self->optvalue, (char **)&s, 0);
+                self->optvalue     = NULL;
+            } else if (self->argc > 1) {
+                self->argc--;
+                *(int *)opt->value = strtol(*++self->argv, (char **)&s, 0);
+            } else {
+                argparse_error(self, opt, "requires a value", flags);
+            }
+            if (errno)
+                argparse_error(self, opt, strerror(errno), flags);
+            if (s[0] != '\0')
+                argparse_error(self, opt, "expects an integer value", flags);
+            break;
+        case ARGPARSE_OPT_FLOAT:
+            errno = 0;
+            if (self->optvalue) {
+                *(float *)opt->value = strtof(self->optvalue, (char **)&s);
+                self->optvalue       = NULL;
+            } else if (self->argc > 1) {
+                self->argc--;
+                *(float *)opt->value = strtof(*++self->argv, (char **)&s);
+            } else {
+                argparse_error(self, opt, "requires a value", flags);
+            }
+            if (errno)
+                argparse_error(self, opt, strerror(errno), flags);
+            if (s[0] != '\0')
+                argparse_error(self, opt, "expects a numerical value", flags);
+            break;
+        default:
+            assert(0);
+    }
+
+    skipped:
+    if (opt->callback) {
+        return opt->callback(self, opt);
+    }
+
+    return 0;
+}
+
+static void
+argparse_options_check(const struct argparse_option *options)
+{
+    for (; options->type != ARGPARSE_OPT_END; options++) {
+        switch (options->type) {
+            case ARGPARSE_OPT_END:
+            case ARGPARSE_OPT_BOOLEAN:
+            case ARGPARSE_OPT_BIT:
+            case ARGPARSE_OPT_INTEGER:
+            case ARGPARSE_OPT_FLOAT:
+            case ARGPARSE_OPT_STRING:
+            case ARGPARSE_OPT_GROUP:
+                continue;
+            default:
+                fprintf(stderr, "wrong option type: %d", options->type);
+                break;
+        }
+    }
+}
+
+static int
+argparse_short_opt(struct argparse *self, const struct argparse_option *options)
+{
+    for (; options->type != ARGPARSE_OPT_END; options++) {
+        if (options->short_name == *self->optvalue) {
+            self->optvalue = self->optvalue[1] ? self->optvalue + 1 : NULL;
+            return argparse_getvalue(self, options, 0);
+        }
+    }
+    return -2;
+}
+
+static int
+argparse_long_opt(struct argparse *self, const struct argparse_option *options)
+{
+    for (; options->type != ARGPARSE_OPT_END; options++) {
+        const char *rest;
+        int opt_flags = 0;
+        if (!options->long_name)
+            continue;
+
+        rest = prefix_skip(self->argv[0] + 2, options->long_name);
+        if (!rest) {
+            // negation disabled?
+            if (options->flags & OPT_NONEG) {
+                continue;
+            }
+            // only OPT_BOOLEAN/OPT_BIT supports negation
+            if (options->type != ARGPARSE_OPT_BOOLEAN && options->type !=
+                                                         ARGPARSE_OPT_BIT) {
+                continue;
+            }
+
+            if (prefix_cmp(self->argv[0] + 2, "no-")) {
+                continue;
+            }
+            rest = prefix_skip(self->argv[0] + 2 + 3, options->long_name);
+            if (!rest)
+                continue;
+            opt_flags |= OPT_UNSET;
+        }
+        if (*rest) {
+            if (*rest != '=')
+                continue;
+            self->optvalue = rest + 1;
+        }
+        return argparse_getvalue(self, options, opt_flags | OPT_LONG);
+    }
+    return -2;
+}
+
+int
+argparse_init(struct argparse *self, struct argparse_option *options,
+              const char *const *usages, int flags)
+{
+    memset(self, 0, sizeof(*self));
+    self->options     = options;
+    self->usages      = usages;
+    self->flags       = flags;
+    self->description = NULL;
+    self->epilog      = NULL;
+    return 0;
+}
+
+void
+argparse_describe(struct argparse *self, const char *description,
+                  const char *epilog)
+{
+    self->description = description;
+    self->epilog      = epilog;
+}
+
+int
+argparse_parse(struct argparse *self, int argc, const char **argv)
+{
+    self->argc = argc - 1;
+    self->argv = argv + 1;
+    self->out  = argv;
+
+    argparse_options_check(self->options);
+
+    for (; self->argc; self->argc--, self->argv++) {
+        const char *arg = self->argv[0];
+        if (arg[0] != '-' || !arg[1]) {
+            if (self->flags & ARGPARSE_STOP_AT_NON_OPTION) {
+                goto end;
+            }
+            // if it's not option or is a single char '-', copy verbatim
+            self->out[self->cpidx++] = self->argv[0];
+            continue;
+        }
+        // short option
+        if (arg[1] != '-') {
+            self->optvalue = arg + 1;
+            switch (argparse_short_opt(self, self->options)) {
+                case -1:
+                    break;
+                case -2:
+                    goto unknown;
+            }
+            while (self->optvalue) {
+                switch (argparse_short_opt(self, self->options)) {
+                    case -1:
+                        break;
+                    case -2:
+                        goto unknown;
+                }
+            }
+            continue;
+        }
+        // if '--' presents
+        if (!arg[2]) {
+            self->argc--;
+            self->argv++;
+            break;
+        }
+        // long option
+        switch (argparse_long_opt(self, self->options)) {
+            case -1:
+                break;
+            case -2:
+                goto unknown;
+        }
+        continue;
+
+        unknown:
+        fprintf(stderr, "error: unknown option `%s`\n", self->argv[0]);
+        argparse_usage(self);
+        exit(1);
+    }
+
+    end:
+    memmove(self->out + self->cpidx, self->argv,
+            self->argc * sizeof(*self->out));
+    self->out[self->cpidx + self->argc] = NULL;
+
+    return self->cpidx + self->argc;
+}
+
+void
+argparse_usage(struct argparse *self)
+{
+    if (self->usages) {
+        fprintf(stdout, "Usage: %s\n", *self->usages++);
+        while (*self->usages && **self->usages)
+            fprintf(stdout, "   or: %s\n", *self->usages++);
+    } else {
+        fprintf(stdout, "Usage:\n");
+    }
+
+    // print description
+    if (self->description)
+        fprintf(stdout, "%s\n", self->description);
+
+    fputc('\n', stdout);
+
+    const struct argparse_option *options;
+
+    // figure out best width
+    size_t usage_opts_width = 0;
+    size_t len;
+    options = self->options;
+    for (; options->type != ARGPARSE_OPT_END; options++) {
+        len = 0;
+        if ((options)->short_name) {
+            len += 2;
+        }
+        if ((options)->short_name && (options)->long_name) {
+            len += 2;           // separator ", "
+        }
+        if ((options)->long_name) {
+            len += strlen((options)->long_name) + 2;
+        }
+        if (options->type == ARGPARSE_OPT_INTEGER) {
+            len += strlen("=<int>");
+        }
+        if (options->type == ARGPARSE_OPT_FLOAT) {
+            len += strlen("=<flt>");
+        } else if (options->type == ARGPARSE_OPT_STRING) {
+            len += strlen("=<str>");
+        }
+        len = (len + 3) - ((len + 3) & 3);
+        if (usage_opts_width < len) {
+            usage_opts_width = len;
+        }
+    }
+    usage_opts_width += 4;      // 4 spaces prefix
+
+    options = self->options;
+    for (; options->type != ARGPARSE_OPT_END; options++) {
+        size_t pos = 0;
+        int pad    = 0;
+        if (options->type == ARGPARSE_OPT_GROUP) {
+            fputc('\n', stdout);
+            fprintf(stdout, "%s", options->help);
+            fputc('\n', stdout);
+            continue;
+        }
+        pos = fprintf(stdout, "    ");
+        if (options->short_name) {
+            pos += fprintf(stdout, "-%c", options->short_name);
+        }
+        if (options->long_name && options->short_name) {
+            pos += fprintf(stdout, ", ");
+        }
+        if (options->long_name) {
+            pos += fprintf(stdout, "--%s", options->long_name);
+        }
+        if (options->type == ARGPARSE_OPT_INTEGER) {
+            pos += fprintf(stdout, "=<int>");
+        } else if (options->type == ARGPARSE_OPT_FLOAT) {
+            pos += fprintf(stdout, "=<flt>");
+        } else if (options->type == ARGPARSE_OPT_STRING) {
+            pos += fprintf(stdout, "=<str>");
+        }
+        if (pos <= usage_opts_width) {
+            pad = usage_opts_width - pos;
+        } else {
+            fputc('\n', stdout);
+            pad = usage_opts_width;
+        }
+        fprintf(stdout, "%*s%s\n", pad + 2, "", options->help);
+    }
+
+    // print epilog
+    if (self->epilog)
+        fprintf(stdout, "%s\n", self->epilog);
+}
+
+int
+argparse_help_cb(struct argparse *self, const struct argparse_option *option)
+{
+    (void)option;
+    argparse_usage(self);
+    exit(0);
+}

--- a/src/cli/argparse.c
+++ b/src/cli/argparse.c
@@ -95,7 +95,7 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
             }
             if (errno)
                 argparse_error(self, opt, strerror(errno), flags);
-            if (s[0] != '\0')
+            if (s != NULL && s[0] != '\0')
                 argparse_error(self, opt, "expects an integer value", flags);
             break;
         case ARGPARSE_OPT_FLOAT:
@@ -111,7 +111,7 @@ argparse_getvalue(struct argparse *self, const struct argparse_option *opt,
             }
             if (errno)
                 argparse_error(self, opt, strerror(errno), flags);
-            if (s[0] != '\0')
+            if (s != NULL && s[0] != '\0')
                 argparse_error(self, opt, "expects a numerical value", flags);
             break;
         default:
@@ -278,7 +278,7 @@ argparse_parse(struct argparse *self, int argc, const char **argv)
     }
 
     end:
-    memmove(self->out + self->cpidx, self->argv,
+    memmove((void *)(self->out + self->cpidx), self->argv,
             self->argc * sizeof(*self->out));
     self->out[self->cpidx + self->argc] = NULL;
 

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2012-2015 Yecheng Fu <cofyc.jackson at gmail dot com>
+ * All rights reserved.
+ *
+ * Use of this source code is governed by a MIT-style license that can be found
+ * in the LICENSE file.
+ */
+#ifndef ARGPARSE_H
+#define ARGPARSE_H
+
+/* For c++ compatibility */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+struct argparse;
+struct argparse_option;
+
+typedef int argparse_callback (struct argparse *self,
+                               const struct argparse_option *option);
+
+enum argparse_flag {
+    ARGPARSE_STOP_AT_NON_OPTION = 1,
+};
+
+enum argparse_option_type {
+    /* special */
+    ARGPARSE_OPT_END,
+    ARGPARSE_OPT_GROUP,
+    /* options with no arguments */
+    ARGPARSE_OPT_BOOLEAN,
+    ARGPARSE_OPT_BIT,
+    /* options with arguments (optional or required) */
+    ARGPARSE_OPT_INTEGER,
+    ARGPARSE_OPT_FLOAT,
+    ARGPARSE_OPT_STRING,
+};
+
+enum argparse_option_flags {
+    OPT_NONEG = 1,              /* disable negation */
+};
+
+/**
+ *  argparse option
+ *
+ *  `type`:
+ *    holds the type of the option, you must have an ARGPARSE_OPT_END last in your
+ *    array.
+ *
+ *  `short_name`:
+ *    the character to use as a short option name, '\0' if none.
+ *
+ *  `long_name`:
+ *    the long option name, without the leading dash, NULL if none.
+ *
+ *  `value`:
+ *    stores pointer to the value to be filled.
+ *
+ *  `help`:
+ *    the short help message associated to what the option does.
+ *    Must never be NULL (except for ARGPARSE_OPT_END).
+ *
+ *  `callback`:
+ *    function is called when corresponding argument is parsed.
+ *
+ *  `data`:
+ *    associated data. Callbacks can use it like they want.
+ *
+ *  `flags`:
+ *    option flags.
+ */
+struct argparse_option {
+    enum argparse_option_type type;
+    const char short_name;
+    const char *long_name;
+    void *value;
+    const char *help;
+    argparse_callback *callback;
+    intptr_t data;
+    int flags;
+};
+
+/**
+ * argpparse
+ */
+struct argparse {
+    // user supplied
+    const struct argparse_option *options;
+    const char *const *usages;
+    int flags;
+    const char *description;    // a description after usage
+    const char *epilog;         // a description at the end
+    // internal context
+    int argc;
+    const char **argv;
+    const char **out;
+    int cpidx;
+    const char *optvalue;       // current option value
+};
+
+// built-in callbacks
+int argparse_help_cb(struct argparse *self,
+                     const struct argparse_option *option);
+
+// built-in option macros
+#define OPT_END()        { ARGPARSE_OPT_END, 0, NULL, NULL, 0, NULL, 0, 0 }
+#define OPT_BOOLEAN(...) { ARGPARSE_OPT_BOOLEAN, __VA_ARGS__ }
+#define OPT_BIT(...)     { ARGPARSE_OPT_BIT, __VA_ARGS__ }
+#define OPT_INTEGER(...) { ARGPARSE_OPT_INTEGER, __VA_ARGS__ }
+#define OPT_FLOAT(...)   { ARGPARSE_OPT_FLOAT, __VA_ARGS__ }
+#define OPT_STRING(...)  { ARGPARSE_OPT_STRING, __VA_ARGS__ }
+#define OPT_GROUP(h)     { ARGPARSE_OPT_GROUP, 0, NULL, NULL, h, NULL, 0, 0 }
+#define OPT_HELP()       OPT_BOOLEAN('h', "help", NULL,                 \
+                                     "Show this help message and exit", \
+                                     argparse_help_cb, 0, OPT_NONEG)
+
+int argparse_init(struct argparse *self, struct argparse_option *options,
+                  const char *const *usages, int flags);
+void argparse_describe(struct argparse *self, const char *description,
+                       const char *epilog);
+int argparse_parse(struct argparse *self, int argc, const char **argv);
+void argparse_usage(struct argparse *self);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "../include/dictu_include.h"
+#include "argparse.h"
 
 #ifndef DISABLE_LINENOISE
 #include "linenoise.h"
@@ -63,9 +64,7 @@ static bool replCountQuotes(char *line) {
 }
 #endif
 
-static void repl(DictuVM *vm, int argc, char *argv[]) {
-    UNUSED(argc); UNUSED(argv);
-
+static void repl(DictuVM *vm) {
     printf(DICTU_STRING_VERSION);
     char *line;
 
@@ -177,35 +176,64 @@ static char *readFile(const char *path) {
     return buffer;
 }
 
-static void runFile(DictuVM *vm, int argc, char *argv[]) {
-    UNUSED(argc);
-
-    char *source = readFile(argv[1]);
+static void runFile(DictuVM *vm, char *filename) {
+    char *source = readFile(filename);
 
     if (source == NULL) {
-        fprintf(stderr, "Could not open file \"%s\".\n", argv[1]);
+        fprintf(stderr, "Could not open file \"%s\".\n", filename);
         exit(74);
     }
 
-    DictuInterpretResult result = dictuInterpret(vm, argv[1], source);
+    DictuInterpretResult result = dictuInterpret(vm, filename, source);
     free(source);
 
     if (result == INTERPRET_COMPILE_ERROR) exit(65);
     if (result == INTERPRET_RUNTIME_ERROR) exit(70);
 }
 
-int main(int argc, char *argv[]) {
-    DictuVM *vm = dictuInitVM(argc == 1, argc, argv);
+static const char *const usage[] = {
+        "dictu [options] [[--] args]",
+        "dictu [options]",
+        NULL,
+};
 
-    if (argc == 1) {
-        repl(vm, argc, argv);
-    } else if (argc >= 2) {
-        runFile(vm, argc, argv);
-    } else {
-        fprintf(stderr, "Usage: dictu [path] [args]\n");
-        exit(64);
+int main(int argc, char *argv[]) {
+    int version;
+    char *cmd = NULL;
+
+    struct argparse_option options[] = {
+            OPT_HELP(),
+            OPT_BOOLEAN('v', "version", &version, "Display Dictu version"),
+            OPT_STRING('c', "cmd", &cmd, "Run program passed in as string"),
+            OPT_END(),
+    };
+
+    struct argparse argparse;
+    argparse_init(&argparse, options, usage, 0);
+    argc = argparse_parse(&argparse, argc, (const char **)argv);
+
+    if (version) {
+        printf(DICTU_STRING_VERSION);
+        return 0;
     }
 
+    DictuVM *vm = dictuInitVM(argc == 0, argc, argv);
+
+    if (cmd != NULL) {
+        DictuInterpretResult result = dictuInterpret(vm, "repl", cmd);
+        if (result == INTERPRET_COMPILE_ERROR) exit(65);
+        if (result == INTERPRET_RUNTIME_ERROR) exit(70);
+        dictuFreeVM(vm);
+        return 0;
+    }
+
+    if (argc == 0) {
+        repl(vm);
+        dictuFreeVM(vm);
+        return 0;
+    }
+
+    runFile(vm, argv[0]);
     dictuFreeVM(vm);
     return 0;
 }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -198,7 +198,7 @@ static const char *const usage[] = {
 };
 
 int main(int argc, char *argv[]) {
-    int version;
+    int version = 0;
     char *cmd = NULL;
 
     struct argparse_option options[] = {

--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -275,7 +275,7 @@ void initArgv(DictuVM *vm, Table *table, int argc, char *argv[]) {
     ObjList *list = newList(vm);
     push(vm, OBJ_VAL(list));
 
-    for (int i = 1; i < argc; i++) {
+    for (int i = 0; i < argc; i++) {
         Value arg = OBJ_VAL(copyString(vm, argv[i], strlen(argv[i])));
         push(vm, arg);
         writeValueArray(vm, &list->values, arg);


### PR DESCRIPTION
# Argument parsing
## Summary
This adds in argument parsing for the CLI. Currently the CLI only has support for the REPL and executing a file with limited customisability, this PR instead implements a [dedicated argument parsing library](https://github.com/cofyc/argparse) along with a couple of new options.

`dictu --help` output
```
Usage: dictu [options] [[--] args]
   or: dictu [options]

    -h, --help        Show this help message and exit
    -v, --version     Display Dictu version
    -c, --cmd=<str>   Run program passed in as string
```