### PR TITLE
Get windows CI/CD working again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,6 @@ jobs:
          - uses: actions/checkout@v2
          - name: Make dictu and run tests (No HTTP No Linenoise)
            run: |
-             cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -DCICD -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
+             cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -DCICD=1 -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
              cmake --build build
              Debug\dictu.exe tests/runTests.du

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,22 +53,17 @@ jobs:
              cmake -DCMAKE_BUILD_TYPE=Debug -B ./build
              cmake --build ./build
              ./dictu tests/runTests.du | tee /dev/stderr | grep -q 'Total memory usage: 0'
+     test-windows-cmake:
+       name: Test on ${{ matrix.os }}
+       runs-on: ${{ matrix.os }}
+       strategy:
+         matrix:
+           os: [windows-2019, windows-2016]
 
-## Seems the MSVC compiler was updated on Actions and we are getting loads of compilation
-## issues with what seems like standard library header files. While investigating windows
-## compilation will be removed from Actions
-#
-#     test-windows-cmake:
-#       name: Test on ${{ matrix.os }}
-#       runs-on: ${{ matrix.os }}
-#       strategy:
-#         matrix:
-#           os: [windows-2019, windows-latest]
-#
-#       steps:
-#         - uses: actions/checkout@v2
-#         - name: Make dictu and run tests (No HTTP No Linenoise)
-#           run: |
-#             cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
-#             cmake --build build
-#             Debug\dictu.exe tests/runTests.du
+       steps:
+         - uses: actions/checkout@v2
+         - name: Make dictu and run tests (No HTTP No Linenoise)
+           run: |
+             cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -DCICD -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
+             cmake --build build
+             Debug\dictu.exe tests/runTests.du

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,10 @@ endif()
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-    set(CMAKE_C_FLAGS "/WX /W1")
+    # An issue on CI/CD with winbase.h producing C5105 warnings
+    if(NOT CICD)
+        set(CMAKE_C_FLAGS "/WX /W1")
+    endif()
     set(CMAKE_C_FLAGS_DEBUG "/Zi")
     set(CMAKE_C_FLAGS_RELEASE "/O2")
 else()


### PR DESCRIPTION
# Windows CI/CD
## Summary
Since a change in versions for the MSVC compiler on actions compilation was failing ([example](https://github.com/dictu-lang/Dictu/pull/330/checks?check_run_id=1424824631)). This PR gets compilation working on actions again for windows versions.