### PR TITLE
Handle scenario where webserver sends no response back correctly

### DIFF
--- a/src/optionals/http.c
+++ b/src/optionals/http.c
@@ -101,7 +101,12 @@ static char *dictToPostArgs(ObjDict *dict) {
 static ObjDict *endRequest(DictuVM *vm, CURL *curl, Response response) {
     // Get status code
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response.statusCode);
-    ObjString *content = takeString(vm, response.res, response.len);
+    ObjString *content;
+    if (response.res != NULL) {
+        content = takeString(vm, response.res, response.len);
+    } else {
+        content = copyString(vm, "", 0);
+    }
 
     // Push to stack to avoid GC
     push(vm, OBJ_VAL(content));


### PR DESCRIPTION
# HTTP
## Summary
In a scenario where a webserver would send no content back a segfault would occur when attempting to generate the content as a `Value` as it would be NULL. This PR resolves this by checking for null and returning an empty string if `writeResponse` is never called.