### PR TITLE
Dark / light mode based on CSS rather than JS

### DIFF
--- a/docs/_includes/css/just-the-docs.scss.liquid
+++ b/docs/_includes/css/just-the-docs.scss.liquid
@@ -2,6 +2,12 @@
 $logo: "{{ site.logo | absolute_url }}";
 {% endif %}
 @import "./support/support";
-@import "./color_schemes/{{ include.color_scheme }}";
+@import "./color_schemes/light";
+@import "./color_schemes/dictu";
 @import "./modules";
+@media (prefers-color-scheme: dark) {
+  @import "./color_schemes/dark";
+  @import "./color_schemes/dictu";
+  @import "./modules";
+}
 {% include css/custom.scss.liquid %}

--- a/docs/_includes/css/just-the-docs.scss.liquid
+++ b/docs/_includes/css/just-the-docs.scss.liquid
@@ -1,13 +1,12 @@
+@charset "UTF-8";
 {% if site.logo %}
 $logo: "{{ site.logo | absolute_url }}";
 {% endif %}
 @import "./support/support";
 @import "./color_schemes/light";
-@import "./color_schemes/dictu";
 @import "./modules";
 @media (prefers-color-scheme: dark) {
   @import "./color_schemes/dark";
-  @import "./color_schemes/dictu";
   @import "./modules";
 }
 {% include css/custom.scss.liquid %}

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -15,27 +15,18 @@
 
     <script>
         (()=>{
-  
-        if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            const cssFile = document.querySelector('[rel="stylesheet"]');
-            const originalCssRef = cssFile.getAttribute('href');
-            const darkModeCssRef = originalCssRef.replace('just-the-docs-default.css', 'just-the-docs-dark.css');
-            cssFile.setAttribute('href', darkModeCssRef);
+            if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                let oldLink = document.getElementById('favicon');
+                let link = document.createElement('link');
+                link.id = 'favicon';
+                link.rel = 'shortcut icon';
+                link.href = '{{ "/assets/favicon-dark.png" | absolute_url }}';
 
-            document.documentElement.classList.add('dark-mode');
-  
-            let oldLink = document.getElementById('favicon');
-            let link = document.createElement('link');
-            link.id = 'favicon';
-            link.rel = 'shortcut icon';
-            link.href = '{{ "/assets/favicon-dark.png" | absolute_url }}';
-  
-            if (oldLink) {
-                document.head.removeChild(oldLink);
+                if (oldLink) {
+                    document.head.removeChild(oldLink);
+                }
+                document.head.appendChild(link);
             }
-            document.head.appendChild(link);
-        }
-  
         })()
     </script>
   

--- a/docs/_sass/color_schemes/dictu.scss
+++ b/docs/_sass/color_schemes/dictu.scss
@@ -1,2 +1,0 @@
-$link-color: #000000;
-$btn-primary-color: #808080;

--- a/docs/_sass/content.scss
+++ b/docs/_sass/content.scss
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 //
 // Styles for rendered markdown in the .main-content container
 //

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -18,13 +18,17 @@ body {
     background-size: auto 20px;
 }
 
-.dark-mode {
+@media (prefers-color-scheme: dark) {
     .site-logo {
         filter: invert(1);
     }
 
-    a {
+    a, a.btn {
         color: #ffffff;
+    }
+
+    .nav-list-expander {
+        color: #2c84fa !important;
     }
 
     .btn.btn-primary {

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -18,17 +18,17 @@ body {
     background-size: auto 20px;
 }
 
+.nav-list-link {
+    color: #000000;
+}
+
 @media (prefers-color-scheme: dark) {
     .site-logo {
         filter: invert(1);
     }
 
-    a, a.btn {
+    .nav-list-link {
         color: #ffffff;
-    }
-
-    .nav-list-expander {
-        color: #2c84fa !important;
     }
 
     .btn.btn-primary {


### PR DESCRIPTION
# Docs
## Summary
Currently the light / dark mode of the documentation website is currently being determined by JS, this means on page load it can sometimes cause a flicker while it transitions to the dark theme - this PR resolves this by correctly handling it through media queries in the CSS rather than through JS.