### PR TITLE
Result.match()

### DIFF
--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -373,7 +373,7 @@ class MyClass {
 var myObject = MyClass("Jason");
 myObject.hello(); // Hello Jason
 
-MyTrait(); // Runtime error: Can only call functions and classes.
+MyTrait(); // Runtime error: 'trait' is not callable
 ```
 
 Sometimes we will have multiple traits, each with slightly different functionality, but we need

--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -73,3 +73,32 @@ Check if a Result type is in a SUCCESS state, returns a boolean.
 "10".toNumber().success(); // true
 "number".toNumber().success(); // false
 ```
+
+### .match(func: success, func: error)
+
+`.match` takes two callbacks that are ran depending upon the status of the result type. The callbacks passed to
+match must both have one parameter each, on success the unwrapped value is passed as the first argument and on
+error the unwrapError reason is passed to the failure callback. The value returned from `.match()` is the value
+returned from the user defined callback.
+
+```cs
+var number = "10".toNumber().match(
+    def (result) => result,
+    def (error) => {
+        print(error);
+        System.exit(1);
+    }
+);
+
+print(number); // 10
+
+var number = "number".toNumber().match(
+    def (result) => result,
+    def (error) => {
+        print(error); // Can not convert to number
+        System.exit(1);
+    }
+);
+
+print(number);
+```

--- a/src/vm/datatypes/generate.du
+++ b/src/vm/datatypes/generate.du
@@ -26,7 +26,8 @@ def generate(filename) {
 }
 
 var files = [
-    'lists/list'
+    'lists/list',
+    'result/result'
 ];
 
 for (var i = 0; i < files.len(); i += 1) {

--- a/src/vm/datatypes/result/result-source.h
+++ b/src/vm/datatypes/result/result-source.h
@@ -1,0 +1,15 @@
+#define DICTU_RESULT_SOURCE "/**\n" \
+" * This file contains all the methods for Results written in Dictu that\n" \
+" * are unable to be written in C due to re-enterability issues.\n" \
+" *\n" \
+" * We should always strive to write methods in C where possible.\n" \
+" */\n" \
+"\n" \
+"def match(result, successCallback, errorCallback) {\n" \
+"    if (result.success()) {\n" \
+"        return successCallback(result.unwrap());\n" \
+"    }\n" \
+"\n" \
+"    return errorCallback(result.unwrapError());\n" \
+"}\n" \
+

--- a/src/vm/datatypes/result/result.c
+++ b/src/vm/datatypes/result/result.c
@@ -1,5 +1,7 @@
 #include "result.h"
 
+#include "result-source.h"
+
 static Value unwrap(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 0) {
         runtimeError(vm, "unwrap() takes no arguments (%d given)", argCount);
@@ -46,4 +48,14 @@ void declareResultMethods(DictuVM *vm) {
     defineNative(vm, &vm->resultMethods, "unwrap", unwrap);
     defineNative(vm, &vm->resultMethods, "unwrapError", unwrapError);
     defineNative(vm, &vm->resultMethods, "success", success);
+
+    dictuInterpret(vm, "Result", DICTU_RESULT_SOURCE);
+
+    Value Result;
+    tableGet(&vm->modules, copyString(vm, "Result", 6), &Result);
+
+    ObjModule *ResultModule = AS_MODULE(Result);
+    push(vm, Result);
+    tableAddAll(vm, &ResultModule->values, &vm->resultMethods);
+    pop(vm);
 }

--- a/src/vm/datatypes/result/result.du
+++ b/src/vm/datatypes/result/result.du
@@ -1,0 +1,14 @@
+/**
+ * This file contains all the methods for Results written in Dictu that
+ * are unable to be written in C due to re-enterability issues.
+ *
+ * We should always strive to write methods in C where possible.
+ */
+
+def match(result, successCallback, errorCallback) {
+    if (result.success()) {
+        return successCallback(result.unwrap());
+    }
+
+    return errorCallback(result.unwrapError());
+}

--- a/src/vm/datatypes/result/result.h
+++ b/src/vm/datatypes/result/result.h
@@ -1,8 +1,8 @@
 #ifndef dictu_result_h
 #define dictu_result_h
 
-#include "../common.h"
-#include "../util.h"
+#include "../../common.h"
+#include "../../util.h"
 
 void declareResultMethods(DictuVM *vm);
 

--- a/src/vm/value.c
+++ b/src/vm/value.c
@@ -433,6 +433,9 @@ char *valueTypeToString(DictuVM *vm, Value value, int *length) {
             case OBJ_FILE: {
                 CONVERT(file, 4);
             }
+            case OBJ_RESULT: {
+                CONVERT(result, 6);
+            }
             default:
                 break;
         }

--- a/tests/result/import.du
+++ b/tests/result/import.du
@@ -1,0 +1,8 @@
+/**
+* import.du
+*
+* General import file for all the dictionary tests
+*/
+
+import "unwrap.du";
+import "match.du";

--- a/tests/result/match.du
+++ b/tests/result/match.du
@@ -1,0 +1,41 @@
+/**
+* match.du
+*
+* Testing Result.match()
+*
+*/
+
+def success(result) {
+    return result;
+}
+
+def error(err) {
+    return err;
+}
+
+var result = Success(10).match(success, error);
+assert(result == 10);
+
+result = Error("Error!").match(success, error);
+assert(result == "Error!");
+
+
+assert(
+  Success([1, 2, 3]).match(
+      def (result) => result,
+      def (err) => err
+  ) == [1, 2, 3]
+);
+
+assert(
+    Error("test").match(
+        def (result) => result,
+        def (err) => err
+    ) == "test"
+);
+
+var number = "10".toNumber().match(success, error);
+assert(number == 10);
+
+var number = "test".toNumber().match(success, error);
+assert(number == "Can not convert to number");

--- a/tests/result/unwrap.du
+++ b/tests/result/unwrap.du
@@ -1,0 +1,18 @@
+/**
+* unwrap.du
+*
+* Testing Result.unwrap(), Result.unwrapError() and Result.success()
+*
+*/
+
+var result = Success(10);
+
+assert(type(result) == "result");
+assert(result.success() == true);
+assert(result.unwrap() == 10);
+
+result = Error("Error!!!");
+
+assert(type(result) == "result");
+assert(result.success() == false);
+assert(result.unwrapError() == "Error!!!");

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -6,6 +6,7 @@ import "variables/import.du";
 import "lists/import.du";
 import "dicts/import.du";
 import "sets/import.du";
+import "result/import.du";
 import "operators/import.du";
 import "loops/import.du";
 import "functions/import.du";


### PR DESCRIPTION
# Result.match()
## Summary
This PR adds a new `Result.match()` method. This method takes two callbacks, one that runs when the result value is of type SUCCESS and the other on ERROR. The callback takes 1 parameter as is passed either the value of `unwrap()` or `unwrapError()` respectively.

This PR also handles result value types when calling `type()`.

### Example
```js
var number = "10".toNumber().match(
    def (result) => result,
    def (error) => {
        print(error);
        System.exit(1);
    }
);

print(number); // 10
```