### PR TITLE
Env.get()

### DIFF
--- a/docs/docs/standard-lib/env.md
+++ b/docs/docs/standard-lib/env.md
@@ -26,7 +26,7 @@ import Env;
 
 ### Env.get(string)
 
-Get an environment variable. `.get()` will return a Result type and on success will unwrap a string.
+Get an environment variable. `.get()` will return a string if a valid environment variable is found otherwise nil.
 
 ```cs
 Env.get("bad key!"); // nil

--- a/src/optionals/env.c
+++ b/src/optionals/env.c
@@ -29,10 +29,10 @@ static Value get(DictuVM *vm, int argCount, Value *args) {
     char *value = getenv(AS_CSTRING(args[0]));
 
     if (value != NULL) {
-        return newResultSuccess(vm, OBJ_VAL(copyString(vm, value, strlen(value))));
+        return OBJ_VAL(copyString(vm, value, strlen(value)));
     }
 
-    return newResultError(vm, "No environment variable set");
+    return NIL_VAL;
 }
 
 static Value set(DictuVM *vm, int argCount, Value *args) {

--- a/tests/env/env.du
+++ b/tests/env/env.du
@@ -7,9 +7,9 @@
  */
 import Env;
 
-assert(Env.get("bad key").success() == false);
+assert(Env.get("bad key") == nil);
 
-Env.set("test", "test");
-assert(Env.get("test").unwrap() == "test");
-Env.set("test", nil);
-assert(Env.get("test").success() == false);
+assert(Env.set("test", "test").success() == true);
+assert(Env.get("test") == "test");
+assert(Env.set("test", nil).success() == true);
+assert(Env.get("test") == nil);


### PR DESCRIPTION
# Env.get()
## Summary
Currently `Env.get()` is returning a result type which unwraps to success on a valid key or an erroneous value if the key doesn't exist. This PR changes this to instead return a string / nil instead of a Result value as getting an env value that doesn't exist isn't a case for error handling. 