### PR TITLE
toNumber error message

### DIFF
--- a/docs/docs/error-handling.md
+++ b/docs/docs/error-handling.md
@@ -65,7 +65,7 @@ attempting to unwrap a Result that is an ERROR gives you a runtime error. Instea
 error.
 
 ```cs
-"num".toNumber().unwrapError(); // 'Can not convert to number'
+"num".toNumber().unwrapError(); // 'Can not convert 'num' to number'
 ```
 
 ### .success()
@@ -98,7 +98,7 @@ print(number); // 10
 var number = "number".toNumber().match(
     def (result) => result,
     def (error) => {
-        print(error); // Can not convert to number
+        print(error); // Can not convert 'number' to number
         System.exit(1);
     }
 );

--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -26,7 +26,19 @@ static Value toNumberString(DictuVM *vm, int argCount, Value *args) {
 
     // Failed conversion
     if (errno != 0 || *end != '\0') {
-        return newResultError(vm, "Can not convert to number");
+        int length = AS_STRING(args[0])->length;
+
+        char *errorMsg = ALLOCATE(vm, char, 29 + length);
+        memcpy(errorMsg, "Can not convert '", 17);
+        memcpy(errorMsg + 17, numberString, length);
+        memcpy(errorMsg + 17 + length, "' to number", 11);
+        errorMsg[28 + length] = '\0';
+
+        Value result = newResultError(vm, errorMsg);
+
+        FREE_ARRAY(vm, char, errorMsg, 29 + length);
+
+        return result;
     }
 
     return newResultSuccess(vm, NUMBER_VAL(number));

--- a/tests/result/match.du
+++ b/tests/result/match.du
@@ -38,4 +38,4 @@ var number = "10".toNumber().match(success, error);
 assert(number == 10);
 
 var number = "test".toNumber().match(success, error);
-assert(number == "Can not convert to number");
+assert(number == "Can not convert 'test' to number");

--- a/tests/strings/toNumber.du
+++ b/tests/strings/toNumber.du
@@ -18,3 +18,10 @@ assert("number".toNumber().success() == false);
 assert("10number".toNumber().success() == false);
 assert("10number10".toNumber().success() == false);
 assert("10..".toNumber().success() == false);
+
+// Test failure reason
+assert("10  ".toNumber().unwrapError() == "Can not convert '10  ' to number");
+assert("number".toNumber().unwrapError() == "Can not convert 'number' to number");
+assert("10number".toNumber().unwrapError() == "Can not convert '10number' to number");
+assert("10number10".toNumber().unwrapError() == "Can not convert '10number10' to number");
+assert("10..".toNumber().unwrapError() == "Can not convert '10..' to number");


### PR DESCRIPTION
# toNumber()
## Summary
This PR updates the error message for `toNumber()` from "Can not convert 'number' to number" to "Can not convert '<string>' to number". This should give a much clearer reason for the conversion failure as you can see the attempted string.