### PR TITLE
Accept GZIP compressed responses

### DIFF
--- a/src/optionals/http.c
+++ b/src/optionals/http.c
@@ -177,6 +177,7 @@ static Value get(DictuVM *vm, int argCount, Value *args) {
 
         curl_easy_setopt(curl, CURLOPT_URL, url);
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+        curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeResponse);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, writeHeaders);
@@ -262,6 +263,7 @@ static Value post(DictuVM *vm, int argCount, Value *args) {
 
         curl_easy_setopt(curl, CURLOPT_URL, url);
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+        curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postValue);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeResponse);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);

--- a/tests/http/get.du
+++ b/tests/http/get.du
@@ -29,3 +29,14 @@ assert(response["headers"].len() > 0);
 response = HTTP.get("https://BAD_URL.test_for_error");
 assert(response.success() == false);
 assert(response.unwrapError() == "Couldn't resolve host name");
+
+// GZIP
+result = HTTP.get("https://httpbin.org/gzip");
+
+assert(result.success());
+response = result.unwrap();
+
+assert(response["statusCode"] == 200);
+assert(response["content"].contains("headers"));
+assert(response["headers"].len() > 0);
+assert(response["headers"].get("Host", false) == "httpbin.org");


### PR DESCRIPTION
# GZIP
## Summary
This sets up both GET and POST requests to accept GZIP responses.