### PR TITLE
List.forEach()

### DIFF
--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -222,15 +222,15 @@ list1.sort();
 print(list1); // [-1, 1, 2, 3, 4, 5, 10]
 ```
 
-### list.foreach(func)
+### list.forEach(func)
 
-To run a function on every element in a list we use `.foreach`. The callback function
-passed to `.foreach` expects one parameter which will be the current value.
+To run a function on every element in a list we use `.forEach`. The callback function
+passed to `.forEach` expects one parameter which will be the current value.
 
 ```cs
 const myList = [1, 2, 3, 4, 5];
 
-myList.foreach(def (value) => {
+myList.forEach(def (value) => {
     print("Val: {}".format(value));
 });
 ```

--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -222,13 +222,25 @@ list1.sort();
 print(list1); // [-1, 1, 2, 3, 4, 5, 10]
 ```
 
+### list.foreach(func)
+
+To run a function on every element in a list we use `.foreach`. The callback function
+passed to `.foreach` expects one parameter which will be the current value.
+
+```cs
+const myList = [1, 2, 3, 4, 5];
+
+myList.foreach(def (value) => {
+    print("Val: {}".format(value));
+});
+```
+
 ### list.map(func)
 
-To run a function on every element in a list we use `.map`. Map expects a single parameter which is a callback
-function which will be ran and the return value will be saved to a list. The callback itself also expects one
+Similar to `.foreach`, `.map` will run a function for each element within the list, however
+the difference is that `.map` returns a new list of values generated from the callback function.
+Map expects a single parameter which is a callback. The callback itself also expects one
 parameter which is the current item in the list.
-
-Note: `.map()` returns a new list.
 
 ```cs
 print([1, 2, 3, 4, 5].map(def (x) => x * 2)); // [2, 4, 6, 8, 10]

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -169,12 +169,19 @@ static void initCompiler(Parser *parser, Compiler *compiler, Compiler *parent, F
         case TYPE_METHOD:
         case TYPE_STATIC:
         case TYPE_ABSTRACT:
-        case TYPE_FUNCTION:
-        case TYPE_ARROW_FUNCTION: {
+        case TYPE_FUNCTION: {
             compiler->function->name = copyString(
                     parser->vm,
                     parser->previous.start,
                     parser->previous.length
+            );
+            break;
+        }
+        case TYPE_ARROW_FUNCTION: {
+            compiler->function->name = copyString(
+                    parser->vm,
+                    "<anonymous>",
+                    11
             );
             break;
         }

--- a/src/vm/datatypes/lists/list-source.h
+++ b/src/vm/datatypes/lists/list-source.h
@@ -37,7 +37,7 @@
 "    return accumulator;\n" \
 "}\n" \
 "\n" \
-"def foreach(list, func) {\n" \
+"def forEach(list, func) {\n" \
 "    for (var i = 0; i < list.len(); i += 1) {\n" \
 "        func(list[i]);\n" \
 "    }\n" \

--- a/src/vm/datatypes/lists/list-source.h
+++ b/src/vm/datatypes/lists/list-source.h
@@ -30,10 +30,16 @@
 "def reduce(list, func, initial=0) {\n" \
 "    var accumulator = initial;\n" \
 "\n" \
-"    for(var i = 0; i < list.len(); i += 1) {\n" \
+"    for (var i = 0; i < list.len(); i += 1) {\n" \
 "        accumulator = func(accumulator, list[i]);\n" \
 "    }\n" \
 "\n" \
 "    return accumulator;\n" \
+"}\n" \
+"\n" \
+"def foreach(list, func) {\n" \
+"    for (var i = 0; i < list.len(); i += 1) {\n" \
+"        func(list[i], i);\n" \
+"    }\n" \
 "}\n" \
 

--- a/src/vm/datatypes/lists/list-source.h
+++ b/src/vm/datatypes/lists/list-source.h
@@ -39,7 +39,7 @@
 "\n" \
 "def foreach(list, func) {\n" \
 "    for (var i = 0; i < list.len(); i += 1) {\n" \
-"        func(list[i], i);\n" \
+"        func(list[i]);\n" \
 "    }\n" \
 "}\n" \
 

--- a/src/vm/datatypes/lists/list.du
+++ b/src/vm/datatypes/lists/list.du
@@ -39,6 +39,6 @@ def reduce(list, func, initial=0) {
 
 def foreach(list, func) {
     for (var i = 0; i < list.len(); i += 1) {
-        func(list[i], i);
+        func(list[i]);
     }
 }

--- a/src/vm/datatypes/lists/list.du
+++ b/src/vm/datatypes/lists/list.du
@@ -37,7 +37,7 @@ def reduce(list, func, initial=0) {
     return accumulator;
 }
 
-def foreach(list, func) {
+def forEach(list, func) {
     for (var i = 0; i < list.len(); i += 1) {
         func(list[i]);
     }

--- a/src/vm/datatypes/lists/list.du
+++ b/src/vm/datatypes/lists/list.du
@@ -30,9 +30,15 @@ def filter(list, func=def(x) => x) {
 def reduce(list, func, initial=0) {
     var accumulator = initial;
 
-    for(var i = 0; i < list.len(); i += 1) {
+    for (var i = 0; i < list.len(); i += 1) {
         accumulator = func(accumulator, list[i]);
     }
 
     return accumulator;
+}
+
+def foreach(list, func) {
+    for (var i = 0; i < list.len(); i += 1) {
+        func(list[i], i);
+    }
 }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -182,7 +182,7 @@ Value peek(DictuVM *vm, int distance) {
 
 static bool call(DictuVM *vm, ObjClosure *closure, int argCount) {
     if (argCount < closure->function->arity || argCount > closure->function->arity + closure->function->arityOptional) {
-        runtimeError(vm, "Function '%s' expected %d arguments but got %d.",
+        runtimeError(vm, "Function '%s' expected %d argument(s) but got %d.",
                      closure->function->name->chars,
                      closure->function->arity + closure->function->arityOptional,
                      argCount

--- a/tests/lists/forEach.du
+++ b/tests/lists/forEach.du
@@ -1,0 +1,16 @@
+/**
+ * foreach.du
+ *
+ * Testing the list.foreach() method
+ *
+ * .foreach() runs a user defined function on each element in the list.
+ */
+
+const myList = [1, 2, 3, 4, 5];
+var accumulator = 0;
+
+myList.forEach(def (value) => {
+    accumulator += value;
+});
+
+assert(accumulator == 15);

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -22,3 +22,4 @@ import "sort.du";
 import "map.du";
 import "filter.du";
 import "reduce.du";
+import "forEach.du";


### PR DESCRIPTION
# List.forEach()
## Summary
This PR adds a new `.forEach()` builtin method to lists. Similar to map in that it allows a callback function to be ran for each element within a list however differs in the fact that it doesn't return anything.