### PR TITLE
Handle constant upvalues correctly

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -294,7 +294,7 @@ static int resolveLocal(Compiler *compiler, Token *name, bool inFunction) {
 // Adds an upvalue to [compiler]'s function with the given properties.
 // Does not add one if an upvalue for that variable is already in the
 // list. Returns the index of the upvalue.
-static int addUpvalue(Compiler *compiler, uint8_t index, bool isLocal) {
+static int addUpvalue(Compiler *compiler, uint8_t index, bool isLocal, bool constant) {
     // Look for an existing one.
     int upvalueCount = compiler->function->upvalueCount;
     for (int i = 0; i < upvalueCount; i++) {
@@ -312,6 +312,7 @@ static int addUpvalue(Compiler *compiler, uint8_t index, bool isLocal) {
 
     compiler->upvalues[upvalueCount].isLocal = isLocal;
     compiler->upvalues[upvalueCount].index = index;
+    compiler->upvalues[upvalueCount].constant = constant;
     return compiler->function->upvalueCount++;
 }
 
@@ -333,7 +334,7 @@ static int resolveUpvalue(Compiler *compiler, Token *name) {
         // Mark the local as an upvalue so we know to close it when it goes
         // out of scope.
         compiler->enclosing->locals[local].isUpvalue = true;
-        return addUpvalue(compiler, (uint8_t) local, true);
+        return addUpvalue(compiler, (uint8_t) local, true, compiler->enclosing->locals[local].constant);
     }
 
     // See if it's an upvalue in the immediately enclosing function. In
@@ -344,7 +345,7 @@ static int resolveUpvalue(Compiler *compiler, Token *name) {
     // deeply nested function that is closing over it.
     int upvalue = resolveUpvalue(compiler->enclosing, name);
     if (upvalue != -1) {
-        return addUpvalue(compiler, (uint8_t) upvalue, false);
+        return addUpvalue(compiler, (uint8_t) upvalue, false, compiler->enclosing->upvalues[upvalue].constant);
     }
 
     // If we got here, we walked all the way up the parent chain and
@@ -1139,6 +1140,12 @@ static void subscript(Compiler *compiler, Token previousToken, bool canAssign) {
 static void checkConst(Compiler *compiler, uint8_t setOp, int arg) {
     if (setOp == OP_SET_LOCAL) {
         if (compiler->locals[arg].constant) {
+            error(compiler->parser, "Cannot assign to a constant.");
+        }
+    } else if (setOp == OP_SET_UPVALUE) {
+        Upvalue upvalue = compiler->upvalues[arg];
+
+        if (upvalue.constant) {
             error(compiler->parser, "Cannot assign to a constant.");
         }
     } else if (setOp == OP_SET_MODULE) {

--- a/src/vm/compiler.h
+++ b/src/vm/compiler.h
@@ -51,6 +51,10 @@ typedef struct {
     // Whether the captured variable is a local or upvalue in the
     // enclosing function.
     bool isLocal;
+
+    // Whether the upvalue was defined as constant
+    // Rather than having to walk a compiler chain (nested closures)
+    bool constant;
 } Upvalue;
 
 typedef struct ClassCompiler {


### PR DESCRIPTION
# Handle constant upvalues correctly
## Summary
Previously when assigning a constant and capturing it as part of a closure the constant could actually be changed as there was no validation on the `SET_UPVALUE` opcode. This PR changes this to ensure constants can't be changed even if captured as part of a closure.