### PR TITLE
Correct indexes for str.replace value type validation

### DIFF
--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -244,7 +244,7 @@ static Value replaceString(DictuVM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
-    if (!IS_STRING(args[0]) || !IS_STRING(args[1])) {
+    if (!IS_STRING(args[1]) || !IS_STRING(args[2])) {
         runtimeError(vm, "Arguments passed to replace() must be a strings");
         return EMPTY_VAL;
     }


### PR DESCRIPTION
# str.replace
Resolves #384 
## Summary
This corrects the indexes used when validating the arguments passed to `str.replace()`