### PR TITLE
Add list.find()

### DIFF
--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -273,3 +273,15 @@ By default the initial value for `.reduce()` is 0, however we can change this to
 ```cs
 print(["Dictu ", "is", " great!"].reduce(def (accumulate, element) => accumulate + element, "")); // 'Dictu is great!'
 ```
+
+### list.find(func)
+
+To find a single item within a list we use `.find()`. Find will search through each item in the list and as soon as the
+callback returns a truthy value, the item that satisfied the callback is returned, if none of the items satisfy the callback
+function then `nil` is returned.
+
+Note: The first item to satisfy the callback is returned.
+
+```cs
+print([1, 2, 3].find(def (item) => item == 2)); // 2
+```

--- a/src/vm/datatypes/lists/list-source.h
+++ b/src/vm/datatypes/lists/list-source.h
@@ -42,4 +42,12 @@
 "        func(list[i]);\n" \
 "    }\n" \
 "}\n" \
+"\n" \
+"def find(list, func) {\n" \
+"    for (var i = 0; i < list.len(); i += 1) {\n" \
+"        if (func(list[i])) {\n" \
+"            return list[i];\n" \
+"        }\n" \
+"    }\n" \
+"}\n" \
 

--- a/src/vm/datatypes/lists/list.du
+++ b/src/vm/datatypes/lists/list.du
@@ -42,3 +42,11 @@ def forEach(list, func) {
         func(list[i]);
     }
 }
+
+def find(list, func) {
+    for (var i = 0; i < list.len(); i += 1) {
+        if (func(list[i])) {
+            return list[i];
+        }
+    }
+}

--- a/tests/lists/find.du
+++ b/tests/lists/find.du
@@ -1,0 +1,13 @@
+/**
+ * find.du
+ *
+ * Testing the list.find() method
+ *
+ * .find() runs a user defined function on each element in the list and returns the item in the
+ * list that satisfies the callback
+ */
+
+const myList = [1, 2, 3, 4, 5];
+
+assert(myList.find(def (item) => item == 3) == 3);
+assert(myList.find(def (item) => item == 10) == nil);

--- a/tests/lists/forEach.du
+++ b/tests/lists/forEach.du
@@ -1,9 +1,9 @@
 /**
- * foreach.du
+ * forEach.du
  *
- * Testing the list.foreach() method
+ * Testing the list.forEach() method
  *
- * .foreach() runs a user defined function on each element in the list.
+ * .forEach() runs a user defined function on each element in the list.
  */
 
 const myList = [1, 2, 3, 4, 5];

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -23,3 +23,4 @@ import "map.du";
 import "filter.du";
 import "reduce.du";
 import "forEach.du";
+import "find.du";


### PR DESCRIPTION
# List.find()
## Summary
This PR adds `list.find()` to Dictu. `.find()` will search through the array and apply a callback function to each element, if the callback returns a truthy value then the item from the list that satisfied the callback is returned.