### PR TITLE
Add built-in method to reverse a list

### DIFF
--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -178,6 +178,14 @@ myList.pop(0); // 1
 print(myList); // [2]
 ```
 
+### list.reverse()
+
+To reverse a list we use `.reverse()`, this will generate a *new* list with the order reversed.
+
+```cs
+print([1, 2, 3].reverse()); // [3, 2, 1]
+```
+
 ### Copying lists
 #### list.copy()
 

--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -180,10 +180,13 @@ print(myList); // [2]
 
 ### list.reverse()
 
-To reverse a list we use `.reverse()`, this will generate a *new* list with the order reversed.
+To reverse a list we use `.reverse()`, this will reverse a list *in-place* (modifying the list) rather than generating a new list.
 
 ```cs
-print([1, 2, 3].reverse()); // [3, 2, 1]
+const myList = [1, 2, 3, 4];
+myList.reverse();
+
+print(myList); // [4, 3, 2, 1]
 ```
 
 ### Copying lists

--- a/src/vm/datatypes/lists/lists.c
+++ b/src/vm/datatypes/lists/lists.c
@@ -383,15 +383,15 @@ static Value reverseList(DictuVM *vm, int argCount, Value *args) {
     }
 
     ObjList* list = AS_LIST(args[0]);
-    ObjList* reversedList = newList(vm);
-    push(vm, OBJ_VAL(reversedList));
+    int listLength = list->values.count;
 
-    for (int i = list->values.count - 1; i >= 0; --i) {
-        writeValueArray(vm, &reversedList->values, list->values.values[i]);
+    for (int i = 0; i < listLength / 2; i++) {
+        Value temp = list->values.values[i];
+        list->values.values[i] = list->values.values[listLength - i - 1];
+        list->values.values[listLength - i - 1] = temp;
     }
-    pop(vm);
 
-    return OBJ_VAL(reversedList);
+    return NIL_VAL;
 }
 
 void declareListMethods(DictuVM *vm) {

--- a/src/vm/datatypes/lists/lists.c
+++ b/src/vm/datatypes/lists/lists.c
@@ -376,6 +376,24 @@ static Value sortList(DictuVM *vm, int argCount, Value *args) {
     return NIL_VAL;
 }
 
+static Value reverseList(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "reverse() takes no arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    ObjList* list = AS_LIST(args[0]);
+    ObjList* reversedList = newList(vm);
+    push(vm, OBJ_VAL(reversedList));
+
+    for (int i = list->values.count - 1; i >= 0; --i) {
+        writeValueArray(vm, &reversedList->values, list->values.values[i]);
+    }
+    pop(vm);
+
+    return OBJ_VAL(reversedList);
+}
+
 void declareListMethods(DictuVM *vm) {
     defineNative(vm, &vm->listMethods, "toString", toStringList);
     defineNative(vm, &vm->listMethods, "len", lenList);
@@ -390,6 +408,7 @@ void declareListMethods(DictuVM *vm) {
     defineNative(vm, &vm->listMethods, "deepCopy", copyListDeep);
     defineNative(vm, &vm->listMethods, "toBool", boolNative); // Defined in util
     defineNative(vm, &vm->listMethods, "sort", sortList);
+    defineNative(vm, &vm->listMethods, "reverse", reverseList);
 
     dictuInterpret(vm, "List", DICTU_LIST_SOURCE);
 

--- a/tests/lists/import.du
+++ b/tests/lists/import.du
@@ -24,3 +24,4 @@ import "filter.du";
 import "reduce.du";
 import "forEach.du";
 import "find.du";
+import "reverse.du";

--- a/tests/lists/reverse.du
+++ b/tests/lists/reverse.du
@@ -5,8 +5,8 @@
  */
 
 const list = [1, 2, 3, 4];
-const reversedList = list.reverse();
+list.reverse();
 
-assert(list != reversedList);
-assert(list.len() == reversedList.len());
-assert(reversedList == [4, 3, 2, 1]);
+assert(list != [1, 2, 3, 4]);
+assert(list.len() == 4);
+assert(list == [4, 3, 2, 1]);

--- a/tests/lists/reverse.du
+++ b/tests/lists/reverse.du
@@ -1,0 +1,12 @@
+/**
+ * reverse.du
+ *
+ * Testing list.reverse()
+ */
+
+const list = [1, 2, 3, 4];
+const reversedList = list.reverse();
+
+assert(list != reversedList);
+assert(list.len() == reversedList.len());
+assert(reversedList == [4, 3, 2, 1]);


### PR DESCRIPTION
# List.reverse()
## Summary
This adds a built-in `.reverse()` method to lists which (as the name suggests) reverses a list.
Note: This reverses a list in-place, if you do not wish to modify the original list make a copy first.