### PR TITLE
Sleep

### DIFF
--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -253,7 +253,7 @@ static Value sleepNative(DictuVM *vm, int argCount, Value *args) {
 #elif _POSIX_C_SOURCE >= 199309L
     struct timespec ts;
     ts.tv_sec = stopTime;
-    ts.tv_nsec = stopTime * 1000000000;
+    ts.tv_nsec = fmod(stopTime, 1) * 1000000000;
     nanosleep(&ts, NULL);
 #else
     if (stopTime >= 1)

--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -248,7 +248,7 @@ static Value sleepNative(DictuVM *vm, int argCount, Value *args) {
 
     double stopTime = AS_NUMBER(args[0]);
 
-#ifdef WIN32
+#ifdef _WIN32
     Sleep(stopTime * 1000);
 #elif _POSIX_C_SOURCE >= 199309L
     struct timespec ts;
@@ -258,9 +258,10 @@ static Value sleepNative(DictuVM *vm, int argCount, Value *args) {
 #else
     if (stopTime >= 1)
       sleep(stopTime);
-    usleep(stopTime * 1000);
-#endif
 
+    // 1000000 = 1 second
+    usleep(fmod(stopTime, 1) * 1000000);
+#endif
 
     return NIL_VAL;
 }

--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -248,11 +248,20 @@ static Value sleepNative(DictuVM *vm, int argCount, Value *args) {
 
     double stopTime = AS_NUMBER(args[0]);
 
-#ifdef _WIN32
+#ifdef WIN32
     Sleep(stopTime * 1000);
+#elif _POSIX_C_SOURCE >= 199309L
+    struct timespec ts;
+    ts.tv_sec = stopTime;
+    ts.tv_nsec = stopTime * 1000000000;
+    nanosleep(&ts, NULL);
 #else
-    sleep(stopTime);
+    if (stopTime >= 1)
+      sleep(stopTime);
+    usleep(stopTime * 1000);
 #endif
+
+
     return NIL_VAL;
 }
 


### PR DESCRIPTION
# Sleep
## Summary
This PR fixes an issue where sleep could not handle a non-integer time (e.g 0.9 seconds).