### PR TITLE
Handle closing file if exiting scope early with return

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -2047,9 +2047,11 @@ static void withStatement(Compiler *compiler) {
     consume(compiler, TOKEN_COMMA, "Expect comma");
     expression(compiler);
     consume(compiler, TOKEN_RIGHT_PAREN, "Expect ')' after 'with'.");
+    consume(compiler, TOKEN_LEFT_BRACE, "Expect '{' before with body.");
 
     beginScope(compiler);
 
+    int fileIndex = compiler->localCount;
     Local *local = &compiler->locals[compiler->localCount++];
     local->depth = compiler->scopeDepth;
     local->isUpvalue = false;
@@ -2057,8 +2059,8 @@ static void withStatement(Compiler *compiler) {
     local->constant = true;
 
     emitByte(compiler, OP_OPEN_FILE);
-    statement(compiler);
-    emitBytes(compiler, OP_CLOSE_FILE, compiler->localCount - 1);
+    block(compiler);
+    emitBytes(compiler, OP_CLOSE_FILE, fileIndex);
     endScope(compiler);
     compiler->withBlock = false;
 }

--- a/src/vm/compiler.h
+++ b/src/vm/compiler.h
@@ -101,6 +101,7 @@ typedef struct Compiler {
     Upvalue upvalues[UINT8_COUNT];
 
     int scopeDepth;
+    bool withBlock;
 } Compiler;
 
 typedef void (*ParsePrefixFn)(Compiler *compiler, bool canAssign);

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -273,7 +273,7 @@ int disassembleInstruction(Chunk *chunk, int offset) {
         case OP_OPEN_FILE:
             return constantInstruction("OP_OPEN_FILE", chunk, offset);
         case OP_CLOSE_FILE:
-            return simpleInstruction("OP_CLOSE_FILE", offset);
+            return constantInstruction("OP_CLOSE_FILE", chunk, offset);
         case OP_BREAK:
             return simpleInstruction("OP_BREAK", offset);
         default:

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1985,11 +1985,8 @@ static DictuInterpretResult run(DictuVM *vm) {
         CASE_CODE(CLOSE_FILE): {
             uint8_t slot = READ_BYTE();
             Value file = frame->slots[slot];
-
-            if (IS_FILE(file)) {
-                ObjFile *fileObject = AS_FILE(file);
-                fclose(fileObject->file);
-            }
+            ObjFile *fileObject = AS_FILE(file);
+            fclose(fileObject->file);
 
             DISPATCH();
         }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1983,8 +1983,14 @@ static DictuInterpretResult run(DictuVM *vm) {
         }
 
         CASE_CODE(CLOSE_FILE): {
-            ObjFile *file = AS_FILE(peek(vm, 0));
-            fclose(file->file);
+            uint8_t slot = READ_BYTE();
+            Value file = frame->slots[slot];
+
+            if (IS_FILE(file)) {
+                ObjFile *fileObject = AS_FILE(file);
+                fclose(fileObject->file);
+            }
+
             DISPATCH();
         }
     }


### PR DESCRIPTION
# File closing
Resolves #391 
## Summary
Previously a file would not be closed correctly if we exited from the with scope with a return statement, this left dangling file handlers lying around. This PR resolves this by emitting `OP_FILE_CLOSE` if a return statement is used in a `with` block.

This PR also fixes an issue where `file` in a with block could be declared as a new variable / constant - this has been fixed so now `file` is reserved within a with block.