### PR TITLE
Send the opcode to close files AFTER the return expression

### DIFF
--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -63,13 +63,7 @@ static Value readFullFile(DictuVM *vm, int argCount, Value *args) {
     // Calculate file size
     fseek(file->file, 0L, SEEK_END);
     size_t fileSize = ftell(file->file);
-    rewind(file->file);
-
-    // Reset cursor position
-    if (currentPosition < fileSize) {
-        fileSize -= currentPosition;
-        fseek(file->file, currentPosition, SEEK_SET);
-    }
+    fseek(file->file, currentPosition, SEEK_SET);
 
     char *buffer = ALLOCATE(vm, char, fileSize + 1);
     if (buffer == NULL) {


### PR DESCRIPTION
# File close
## Summary
#392 fixed an issue with file descriptors not being closed when exiting from a with scope early, however, it introduced an issue where it was actually closing the file handle **before** evaluating the return statement, this meant if you were returning an expression that included something to do with the file, it would not work correctly. This PR resolves that issue.