### PR TITLE
Fix issue where list to string resizing wasn't correct

### DIFF
--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -263,11 +263,11 @@ char *listToString(Value value) {
             elementSize = strlen(element);
         }
 
-        if (elementSize > (size - listStringLength - 3)) {
-            if (elementSize > size * 2) {
-                size += elementSize * 2 + 3;
+        if (elementSize > (size - listStringLength - 6)) {
+            if (elementSize > size) {
+                size = size + elementSize * 2 + 6;
             } else {
-                size = size * 2 + 3;
+                size = size * 2 + 6;
             }
 
             char *newB = realloc(listString, sizeof(char) * size);


### PR DESCRIPTION
# List resizing
## Summary
The logic was checking if the element size was greater than 2 times the current allocated memory length when it should have been just the allocated length (since it's getting doubled). It also didn't account for quotes added around string values and the null terminator.
