### PR TITLE
Update examples and correctly handle constants for the repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ Refer to [Dictu Docker](https://github.com/dictu-lang/Dictu/blob/develop/Docker/
 
 ## Example program
 ```js
-var userInput;
-var guess = 10;
+const guess = 10;
 
 while {
-    userInput = input("Input your guess: ").toNumber().unwrap();
+    const userInput = input("Input your guess: ").toNumber().unwrap();
     if (userInput == guess) {
         print("Well done!");
         break;

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,11 +13,8 @@ class Person {
     // Use the trait and inherit the methods
     use PrintNameTrait;
 
-    // Class constructor
-    init(name, age) {
-        this.name = name;
-        this.age = age;
-    }
+    // Class constructor, set name and age as public instance variables
+    init(var name, var age) {}
 
     // Define a new method
     printAge() {
@@ -30,11 +27,8 @@ class Car {
     // Use the trait and inherit the methods
     use PrintNameTrait;
 
-    // Class constructor
-    init(name, model) {
-        this.name = name;
-        this.model = model;
-    }
+    // Class constructor, set name and model as public instance variables
+    init(var name, var model) {}
 
     // Define a new method
     printModel() {
@@ -43,7 +37,7 @@ class Car {
 }
 
 // Instantiate a new Person object
-var jason = Person("Jason", 500);
+const jason = Person("Jason", 500);
 
 // Call the method defined in the trait
 jason.printName();
@@ -52,7 +46,7 @@ jason.printName();
 jason.printAge();
 
 // Instantiate a new Car object
-var cayman = Car("Cayman", "Porsche");
+const cayman = Car("Cayman", "Porsche");
 
 // Call the method defined in the trait
 cayman.printName();
@@ -85,7 +79,7 @@ if (amount > 0) {
 ## FizzBuzz
 
 ```js
-for (var i = 1; i < 101; ++i) {
+for (var i = 1; i < 101; i += 1) {
     if (i % 15 == 0) {
         print("FizzBuzz");
     } else if (i % 3 == 0) {
@@ -101,11 +95,10 @@ for (var i = 1; i < 101; ++i) {
 ## Guessing Game
 
 ```js
-var guess = 10;
+const guess = 10;
 
 while {
-    var userInput = input("Input your guess: ").toNumber();
-    print(userInput);
+    const userInput = input("Input your guess: ").toNumber().unwrap();
     if (userInput == guess) {
         print("Well done!");
         break;

--- a/examples/bubbleSort.du
+++ b/examples/bubbleSort.du
@@ -1,17 +1,17 @@
 def bubbleSort(list) {
- var sortedList = list.copy();
+    const sortedList = list.copy();
 
-  for (var i = 0; i < sortedList.len(); i += 1) {
-    for (var j = 0; j < sortedList.len() - 1; ++j) {
-      if (sortedList[j] > sortedList[j+1]) {
-        var temp = sortedList[j+1];
-        sortedList[j+1] = sortedList[j];
-        sortedList[j] = temp;
-      }
+    for (var i = 0; i < sortedList.len(); i += 1) {
+        for (var j = 0; j < sortedList.len() - 1; j += 1) {
+            if (sortedList[j] > sortedList[j + 1]) {
+                var temp = sortedList[j + 1];
+                sortedList[j + 1] = sortedList[j];
+                sortedList[j] = temp;
+            }
+        }
     }
-  }
 
- return sortedList;
+    return sortedList;
 }
 
 print(bubbleSort([2, 1, 3, 4, 10, 5, 6, 5, 100, -1])); // [-1, 1, 2, 3, 4, 5, 5, 6, 10, 100]

--- a/examples/classes.du
+++ b/examples/classes.du
@@ -10,11 +10,8 @@ class Person {
     // Use the trait and inherit the methods
     use PrintNameTrait;
 
-    // Class constructor
-    init(name, age) {
-        this.name = name;
-        this.age = age;
-    }
+    // Class constructor, set name and age as public instance variables
+    init(var name, var age) {}
 
     // Define a new method
     printAge() {
@@ -27,11 +24,8 @@ class Car {
     // Use the trait and inherit the methods
     use PrintNameTrait;
 
-    // Class constructor
-    init(name, model) {
-        this.name = name;
-        this.model = model;
-    }
+    // Class constructor, set name and model as public instance variables
+    init(var name, var model) {}
 
     // Define a new method
     printModel() {
@@ -40,7 +34,7 @@ class Car {
 }
 
 // Instantiate a new Person object
-var jason = Person("Jason", 500);
+const jason = Person("Jason", 500);
 
 // Call the method defined in the trait
 jason.printName();
@@ -49,7 +43,7 @@ jason.printName();
 jason.printAge();
 
 // Instantiate a new Car object
-var cayman = Car("Cayman", "Porsche");
+const cayman = Car("Cayman", "Porsche");
 
 // Call the method defined in the trait
 cayman.printName();

--- a/examples/guessingGame.du
+++ b/examples/guessingGame.du
@@ -1,7 +1,7 @@
-var guess = 10;
+const guess = 10;
 
 while {
-    var userInput = input("Input your guess: ").toNumber().unwrap();
+    const userInput = input("Input your guess: ").toNumber().unwrap();
     if (userInput == guess) {
         print("Well done!");
         break;

--- a/examples/inheritance.du
+++ b/examples/inheritance.du
@@ -24,8 +24,8 @@ class Cat < Animal {
 }
 
 // Initialize child class
-var dog = Dog();
-var cat = Cat();
+const dog = Dog();
+const cat = Cat();
 
 // Inherited methods/behaviour from parent class - Animal
 dog.eating();

--- a/examples/isPalindrome.du
+++ b/examples/isPalindrome.du
@@ -1,12 +1,12 @@
 def isPalindrome(arg) {
-  var len = arg.len();
-  for (var i = 0; i < len/2; i += 1) {
-    if (arg[i] != arg[len - 1 - i]) { 
-        return false; 
+    const len = arg.len();
+    for (var i = 0; i < len / 2; i += 1) {
+        if (arg[i] != arg[len - 1 - i]) {
+            return false;
+        }
+
     }
-    
-  }
-  return true;
+    return true;
 }
 
 print(isPalindrome("aba")); // true

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -2431,7 +2431,10 @@ ObjFunction *compile(DictuVM *vm, ObjModule *module, const char *source) {
 
     ObjFunction *function = endCompiler(&compiler);
 
-    freeTable(vm, &vm->constants);
+    // If we're in the repl we need the constants to live for the entirety of the execution
+    if (!vm->repl) {
+        freeTable(vm, &vm->constants);
+    }
 
     // If there was a compile error, the code is not valid, so don't
     // create a function.

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -135,6 +135,10 @@ DictuVM *dictuInitVM(bool repl, int argc, char *argv[]) {
 }
 
 void dictuFreeVM(DictuVM *vm) {
+    if (vm->repl) {
+        freeTable(vm, &vm->constants);
+    }
+
     freeTable(vm, &vm->modules);
     freeTable(vm, &vm->globals);
     freeTable(vm, &vm->constants);


### PR DESCRIPTION
# Cleanup
## Summary
This PR fixes a slight issue where constants defined within the REPL could be re-assigned along with updating the example Dictu programs to bring them more in-line with what they should be.