### PR TITLE
Update dockerfiles to pull from git instead of local

### DIFF
--- a/Docker/DictuAlpineDockerfile
+++ b/Docker/DictuAlpineDockerfile
@@ -2,13 +2,12 @@ FROM alpine
 
 WORKDIR Dictu
 
-RUN apk add make curl-dev gcc libc-dev cmake --no-cache
+RUN apk add git make curl-dev gcc libc-dev cmake --no-cache
 
-COPY CMakeLists.txt .
-COPY src ./src/
-COPY tests ./tests/
+RUN git clone https://github.com/dictu-lang/Dictu.git
 
-RUN cmake -DCMAKE_BUILD_TYPE=Release -B build \
+RUN cd Dictu \
+    && cmake -DCMAKE_BUILD_TYPE=Release -B build \
     && cmake --build ./build \
     && ./dictu tests/runTests.du \
 	&& cp dictu /usr/bin/ \

--- a/Docker/DictuUbuntuDockerfile
+++ b/Docker/DictuUbuntuDockerfile
@@ -7,14 +7,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends build-essential \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends cmake libcurl4-gnutls-dev \
+	&& apt-get install -y --reinstall ca-certificates \
+	&& apt-get install -y --no-install-recommends git cmake libcurl4-gnutls-dev \
     && rm -rf /var/lib/apt/lists/*
 
-COPY CMakeLists.txt .
-COPY src ./src/
-COPY tests ./tests/
+RUN git clone https://github.com/dictu-lang/Dictu.git
 
-RUN cmake -DCMAKE_BUILD_TYPE=Release -B build \
+RUN cd Dictu \
+    && cmake -DCMAKE_BUILD_TYPE=Release -B build \
     && cmake --build ./build \
     && ./dictu tests/runTests.du \
 	&& cp dictu /usr/bin/ \

--- a/src/optionals/process.c
+++ b/src/optionals/process.c
@@ -174,7 +174,9 @@ static Value executeReturnOutput(DictuVM* vm, ObjList* argList) {
     arguments[argList->values.count] = NULL;
 
     int fd[2];
-    pipe(fd);
+    if (pipe(fd) != 0) {
+        ERROR_RESULT;
+    }
     pid_t pid = fork();
     if (pid == 0) {
         close(fd[0]);


### PR DESCRIPTION
# Dockerfile
## Summary
This PR updates the dockerfiles to pull from git rather than rely on the source being locally available already. This means services such as dockerhub can be used to build images. It also fixes an issue where the return of pipe wasn't being used.