### PR TITLE
Error reporting

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -6,6 +6,7 @@
 #include "compiler.h"
 #include "memory.h"
 #include "vm.h"
+#include "error_lib/error.h"
 #include "../optionals/optionals.h"
 
 #ifdef DEBUG_PRINT_CODE
@@ -22,17 +23,22 @@ static void errorAt(Parser *parser, Token *token, const char *message) {
     if (parser->panicMode) return;
     parser->panicMode = true;
 
-    fprintf(stderr, "[%s line %d] Error", parser->module->name->chars, token->line);
+    log_error("File '%s', {bold}line %d{reset}", parser->module->name->chars, token->line);
 
-    if (token->type == TOKEN_EOF) {
-        fprintf(stderr, " at end");
-    } else if (token->type == TOKEN_ERROR) {
-        // Nothing.
-    } else {
-        fprintf(stderr, " at '%.*s'", token->length, token->start);
+    switch (token->type) {
+        case TOKEN_EOF:
+            log_padln("Error at end: %s", message);
+            break;
+        case TOKEN_ERROR:
+            log_padln("Error: %s", message);
+            break;
+        default:
+            log_padln("%zu %s %.*s", token->line, "|", token->length, token->start);
+            log_padln("%s", message);
+            break;
     }
 
-    fprintf(stderr, ": %s\n", message);
+    fputc('\n', stderr);
     parser->hadError = true;
 }
 

--- a/src/vm/error_lib/LICENSE
+++ b/src/vm/error_lib/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Edward Bruce
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/vm/error_lib/README.md
+++ b/src/vm/error_lib/README.md
@@ -1,0 +1,3 @@
+# Error lib
+
+The error lib used to generate compile and runtime errors is from [https://github.com/cometodukey/tbd](https://github.com/cometodukey/tbd) 

--- a/src/vm/error_lib/error.c
+++ b/src/vm/error_lib/error.c
@@ -14,8 +14,8 @@ struct TextAttr
 };
 
 static size_t
-log_fmt_parse(const size_t dst_size, char dst[dst_size],
-              const size_t src_size, const char src[src_size])
+log_fmt_parse(const size_t dst_size, char *dst,
+              const size_t src_size, const char *src)
 {
     size_t log_fmt_size = 0;
 
@@ -31,6 +31,23 @@ log_fmt_parse(const size_t dst_size, char dst[dst_size],
 
             const size_t end = --src_i;
 
+#ifdef _WIN32
+            static const struct TextAttr attrs[] = {
+                { "reset",     ""  },
+                { "bold",      ""  },
+                { "dim",       ""  },
+                { "italic",    ""  },
+                { "underline", ""  },
+                { "black",     ""  },
+                { "red",       ""  },
+                { "green",     ""  },
+                { "yellow",    ""  },
+                { "blue",      ""  },
+                { "magenta",   ""  },
+                { "cyan",      ""  },
+                { "white",     ""  }
+            };
+#else // _WIN32
             static const struct TextAttr attrs[] = {
                 { "reset",     "\033[0m"  },
                 { "bold",      "\033[1m"  },
@@ -46,6 +63,7 @@ log_fmt_parse(const size_t dst_size, char dst[dst_size],
                 { "cyan",      "\033[36m" },
                 { "white",     "\033[37m" }
             };
+#endif // _WIN32
 
             for (size_t i = 0; i < (sizeof(attrs) / sizeof(*(attrs))); i++)
             {
@@ -111,14 +129,14 @@ vlog(const enum LogType type, const char *fmt, va_list args, const bool newline)
 
     static const struct TextAttr prefix[] = {
         [LOG_NONE]    = { "",            ""                          },
-        [LOG_INFO]    = { "info",        "{white}%s:{reset} "        },
-        [LOG_NOTE]    = { "note",        "{dim}%s: "                 },
+        [LOG_INFO]    = { "Info",        "{white}%s:{reset} "        },
+        [LOG_NOTE]    = { "Note",        "{dim}%s: "                 },
         [LOG_PAD]     = { "",            ""                          },
         [LOG_DEBUG]   = { "DEBUG",       "{bold}{white}%s:{reset} "  },
-        [LOG_SUCCESS] = { "success",     "(bold}{green}%s:{reset} "  },
-        [LOG_WARNING] = { "warning",     "{bold}{yellow}%s:{reset} " },
-        [LOG_ERROR]   = { "error",       "{bold}{red}%s:{reset} "    },
-        [LOG_FATAL]   = { "fatal error", "{bold}{red}%s:{reset} "    },
+        [LOG_SUCCESS] = { "Success",     "(bold}{green}%s:{reset} "  },
+        [LOG_WARNING] = { "Warning",     "{bold}{yellow}%s:{reset} " },
+        [LOG_ERROR]   = { "Error",       "{bold}{red}%s:{reset} "    },
+        [LOG_FATAL]   = { "Fatal Error", "{bold}{red}%s:{reset} "    },
         [LOG_BUG]     = { "BUG",         "{bold}{red}%s:{reset} "    }
     };
 

--- a/src/vm/error_lib/error.c
+++ b/src/vm/error_lib/error.c
@@ -1,0 +1,287 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "error.h"
+#include "term.h"
+
+struct TextAttr
+{
+    const char *name;
+    const char *attr;
+};
+
+static size_t
+log_fmt_parse(const size_t dst_size, char dst[dst_size],
+              const size_t src_size, const char src[src_size])
+{
+    size_t log_fmt_size = 0;
+
+    size_t src_i = 0;
+    for (size_t dst_i = 0; dst_i < dst_size && src_i < src_size; dst_i++, src_i++)
+    {
+        if (src[src_i] == '{')
+        {
+            const size_t start = ++src_i;
+
+            while (src_i < src_size && src[src_i++] != '}')
+                ; /* Find the closing brace */
+
+            const size_t end = --src_i;
+
+            static const struct TextAttr attrs[] = {
+                { "reset",     "\033[0m"  },
+                { "bold",      "\033[1m"  },
+                { "dim",       "\033[2m"  },
+                { "italic",    "\033[3m"  },
+                { "underline", "\033[4m"  },
+                { "black",     "\033[30m" },
+                { "red",       "\033[31m" },
+                { "green",     "\033[32m" },
+                { "yellow",    "\033[33m" },
+                { "blue",      "\033[34m" },
+                { "magenta",   "\033[35m" },
+                { "cyan",      "\033[36m" },
+                { "white",     "\033[37m" }
+            };
+
+            for (size_t i = 0; i < (sizeof(attrs) / sizeof(*(attrs))); i++)
+            {
+                if (!strncmp(attrs[i].name, &src[start], end - start))
+                {
+                    strcpy(&dst[dst_i], attrs[i].attr);
+                    const size_t attr_len = strlen(attrs[i].attr);
+                    dst_i += attr_len - 1;
+                    log_fmt_size += attr_len;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            dst[dst_i] = src[src_i];
+            dst[dst_i + 1] = '\0';
+        }
+    }
+
+    return log_fmt_size;
+}
+
+static size_t
+internal_prettyvlog(FILE *f, const char *fmt, va_list args)
+{
+    assert(f != NULL);
+    assert(fmt != NULL);
+
+    const size_t fmt_len = strlen(fmt);
+    const size_t size = (fmt_len * 2) + 7;
+    char *buf = malloc(size);
+
+    buf[0] = '\0';
+    const size_t log_fmt_size = log_fmt_parse(size, buf, fmt_len, fmt);
+    buf[size - 1] = '\0';
+
+    const size_t vfprintf_printed = vfprintf(f, buf, args);
+
+    free(buf);
+
+    return vfprintf_printed - log_fmt_size;
+}
+
+static size_t
+internal_prettylog(FILE *f, const char *fmt, ...)
+{
+    assert(f != NULL);
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    const size_t printed_len = internal_prettyvlog(f, fmt, args);
+    va_end(args);
+
+    return printed_len;
+}
+
+void
+vlog(const enum LogType type, const char *fmt, va_list args, const bool newline)
+{
+    assert(fmt != NULL);
+
+    static const struct TextAttr prefix[] = {
+        [LOG_NONE]    = { "",            ""                          },
+        [LOG_INFO]    = { "info",        "{white}%s:{reset} "        },
+        [LOG_NOTE]    = { "note",        "{dim}%s: "                 },
+        [LOG_PAD]     = { "",            ""                          },
+        [LOG_DEBUG]   = { "DEBUG",       "{bold}{white}%s:{reset} "  },
+        [LOG_SUCCESS] = { "success",     "(bold}{green}%s:{reset} "  },
+        [LOG_WARNING] = { "warning",     "{bold}{yellow}%s:{reset} " },
+        [LOG_ERROR]   = { "error",       "{bold}{red}%s:{reset} "    },
+        [LOG_FATAL]   = { "fatal error", "{bold}{red}%s:{reset} "    },
+        [LOG_BUG]     = { "BUG",         "{bold}{red}%s:{reset} "    }
+    };
+
+    static size_t last_printed_length = 0;
+
+    if (type == LOG_NONE)
+        {}
+    else if (type == LOG_PAD)
+        last_printed_length = internal_prettylog(stderr, "%*.s", last_printed_length, "");
+    else
+        last_printed_length = internal_prettylog(stderr, prefix[type].attr, prefix[type].name);
+
+    internal_prettyvlog(stderr, fmt, args);
+
+    if (newline)
+        fputc('\n', stderr);
+}
+
+static void
+internal_log(const enum LogType type, const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(type, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_none(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_NONE, fmt, args, false);
+    va_end(args);
+}
+
+void
+log_noneln(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_NONE, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_info(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_INFO, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_note(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_NOTE, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_pad(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_PAD, fmt, args, false);
+    va_end(args);
+}
+
+void
+log_padln(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_PAD, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_debug(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_DEBUG, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_success(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_SUCCESS, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_warning(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_WARNING, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_error(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_ERROR, fmt, args, true);
+    va_end(args);
+}
+
+void
+log_fatal(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_FATAL, fmt, args, true);
+    va_end(args);
+
+    internal_log(LOG_FATAL, "Exiting due to previous error.");
+    exit(EXIT_FAILURE);
+}
+
+void
+log_bug(const char *fmt, ...)
+{
+    assert(fmt != NULL);
+
+    va_list args;
+    va_start(args, fmt);
+    vlog(LOG_BUG, fmt, args, true);
+    va_end(args);
+
+    internal_log(LOG_BUG, "Aborting due to previous error.");
+    abort();
+}

--- a/src/vm/error_lib/error.h
+++ b/src/vm/error_lib/error.h
@@ -1,0 +1,47 @@
+#ifndef __ERROR_H__
+#define __ERROR_H__
+
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+// TODO: Dump command line, version, build options when BUG() is called
+
+#define LOG_BUG(...) log_bug(__VA_ARGS__)
+#define LOG_DEBUG(...) log_debug(__VA_ARGS__)
+
+enum LogType
+{
+    LOG_NONE,
+    LOG_INFO,
+    LOG_NOTE,
+    LOG_PAD,
+    LOG_DEBUG,
+    LOG_SUCCESS,
+    LOG_WARNING,
+    LOG_ERROR,
+    LOG_FATAL,
+    LOG_BUG
+};
+
+void vlog(const enum LogType type, const char *fmt, va_list args, const bool newline);
+void log_none(const char *fmt, ...);
+void log_noneln(const char *fmt, ...);
+void log_info(const char *fmt, ...);
+void log_note(const char *fmt, ...);
+void log_pad(const char *fmt, ...);
+void log_padln(const char *fmt, ...);
+void log_debug(const char *fmt, ...);
+void log_success(const char *fmt, ...);
+void log_warning(const char *fmt, ...);
+void log_error(const char *fmt, ...);
+void log_fatal(const char *fmt, ...);
+void log_bug(const char *fmt, ...);
+
+#endif /* __ERROR_H__ */
+
+// info() success() note() warning() error() fatal() bug() debug() pad() - to previous error prefix length
+// logging_disable_colour(), !isatty(stdout)
+// logging_disable_utf8(), !strstr(getenv("LANG"), "UTF-8")
+// {bold}, {dim}, {italic}, {underline}, {reset}
+// {black}, {red}, {green}, {yellow}, {blue}, {magenta}, {cyan}, {white}

--- a/src/vm/error_lib/term.c
+++ b/src/vm/error_lib/term.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "term.h"
+
+/* FIXME: These are unreliable */
+
+bool
+term_supports_utf8(void)
+{
+    const char *lang = getenv("LANG");
+    if (lang != NULL && (strstr(lang, "UTF-8") || strstr(lang, "UTF8")))
+        return true;
+    return false;
+}
+
+bool
+term_supports_colour(void)
+{
+    const char *term = getenv("TERM");
+    if (term != NULL && strstr(term, "color"))
+        return true;
+    return false;
+}

--- a/src/vm/error_lib/term.h
+++ b/src/vm/error_lib/term.h
@@ -1,0 +1,9 @@
+#ifndef __TERM_H__
+#define __TERM_H__
+
+#include <stdbool.h>
+
+bool term_supports_utf8(void);
+bool term_supports_colour(void);
+
+#endif /* __TERM_H__ */


### PR DESCRIPTION
# Error reporting
## Summary
This PR updates the error reporting to add a little bit of colour (non-windows) along with the option to further extend error reporting. It also changes the error warning for the `+` operator from `"Unsupported operand types for +: 10, 'test'"` to `Unsupported operand types for +: 'number', 'string'`.

## Examples
<img width="472" alt="Screenshot 2021-06-26 at 17 13 54" src="https://user-images.githubusercontent.com/20248039/123519278-12007d00-d6a2-11eb-9e00-edd945432b27.png">

## Credit
The system to handle different formatting and colours was taken from [this](https://github.com/cometodukey/tbd) repository, thanks @cometodukey!