### PR TITLE
Fix printing bound methods

### DIFF
--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -537,32 +537,32 @@ char *objectToString(Value value) {
             char *methodString;
 
             if (method->method->function->name != NULL) {
-                methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
-
                 switch (method->method->function->type) {
                     case TYPE_STATIC: {
-                        snprintf(methodString, method->method->function->name->length + 17, "<Bound Method %s>", method->method->function->name->chars);
+                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
+                        snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
                         break;
                     }
 
                     default: {
-                        snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
+                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 16));
+                        snprintf(methodString, method->method->function->name->length + 16, "<Bound Method %s>", method->method->function->name->chars);
                         break;
                     }
                 }
             } else {
-                methodString = malloc(sizeof(char) * 16);
-
                 switch (method->method->function->type) {
                     case TYPE_STATIC: {
+                        methodString = malloc(sizeof(char) * 16);
                         memcpy(methodString, "<Static Method>", 15);
                         methodString[15] = '\0';
                         break;
                     }
 
                     default: {
-                        memcpy(methodString, "<Bound Method>", 15);
-                        methodString[15] = '\0';
+                        methodString = malloc(sizeof(char) * 15);
+                        memcpy(methodString, "<Bound Method>", 14);
+                        methodString[14] = '\0';
                         break;
                     }
                 }


### PR DESCRIPTION
# Bound Methods
## Summary
When printing methods which are bound to a class, it is incorrectly printing static as bound methods and bound methods as static methods.

```
class Test {
    init() {
        print(this.func); // <Static Method func>
        print(this.func1); // <Bound Method func1>
    }

    func() {}

    static func1() {}
}

Test();
```

This PR resolves this.
