### PR TITLE
dict.forEach()

### DIFF
--- a/docs/docs/collections/dictionaries.md
+++ b/docs/docs/collections/dictionaries.md
@@ -131,3 +131,16 @@ var myDict = {"key": {"test": 10}};
 var myDict1 = myDict.copy(); // Shallow copy
 var myDict2 = myDict.deepCopy(); // Deep copy
 ```
+
+### dict.forEach(func)
+
+To run a function on every element in a dictionary we use `.forEach`. The callback function
+passed to `.forEach` expects two parameters which will be the key-value pair of the dictionary.
+
+```cs
+const myDict = {"key": 1, "key1": 2};
+
+myDict.forEach(def (key, value) => {
+    print("Key: {} Value: {}".format(key, value));
+});
+```

--- a/src/vm/datatypes/dicts/dict-source.h
+++ b/src/vm/datatypes/dicts/dict-source.h
@@ -1,5 +1,5 @@
 #define DICTU_DICT_SOURCE "/**\n" \
-" * This file contains all the methods for Lists written in Dictu that\n" \
+" * This file contains all the methods for Dicts written in Dictu that\n" \
 " * are unable to be written in C due to re-enterability issues.\n" \
 " *\n" \
 " * We should always strive to write methods in C where possible.\n" \

--- a/src/vm/datatypes/dicts/dict-source.h
+++ b/src/vm/datatypes/dicts/dict-source.h
@@ -1,0 +1,14 @@
+#define DICTU_DICT_SOURCE "/**\n" \
+" * This file contains all the methods for Lists written in Dictu that\n" \
+" * are unable to be written in C due to re-enterability issues.\n" \
+" *\n" \
+" * We should always strive to write methods in C where possible.\n" \
+" */\n" \
+"def forEach(dict, func) {\n" \
+"    const dictKeys = dict.keys();\n" \
+"\n" \
+"    for (var i = 0; i < dictKeys.len(); i += 1) {\n" \
+"        func(dictKeys[i], dict[dictKeys[i]]);\n" \
+"    }\n" \
+"}\n" \
+

--- a/src/vm/datatypes/dicts/dict.du
+++ b/src/vm/datatypes/dicts/dict.du
@@ -1,5 +1,5 @@
 /**
- * This file contains all the methods for Lists written in Dictu that
+ * This file contains all the methods for Dicts written in Dictu that
  * are unable to be written in C due to re-enterability issues.
  *
  * We should always strive to write methods in C where possible.

--- a/src/vm/datatypes/dicts/dict.du
+++ b/src/vm/datatypes/dicts/dict.du
@@ -1,0 +1,13 @@
+/**
+ * This file contains all the methods for Lists written in Dictu that
+ * are unable to be written in C due to re-enterability issues.
+ *
+ * We should always strive to write methods in C where possible.
+ */
+def forEach(dict, func) {
+    const dictKeys = dict.keys();
+
+    for (var i = 0; i < dictKeys.len(); i += 1) {
+        func(dictKeys[i], dict[dictKeys[i]]);
+    }
+}

--- a/src/vm/datatypes/dicts/dicts.c
+++ b/src/vm/datatypes/dicts/dicts.c
@@ -1,5 +1,15 @@
 #include "dicts.h"
 
+/*
+ * Note: We should try to implement everything we can in C
+ *       rather than in the host language as C will always
+ *       be faster than Dictu, and there will be extra work
+ *       at startup running the Dictu code, however compromises
+ *       must be made due to the fact the VM is not re-enterable
+ */
+
+#include "dict-source.h"
+
 static Value toStringDict(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 0) {
         runtimeError(vm, "toString() takes no arguments (%d given)", argCount);
@@ -156,4 +166,14 @@ void declareDictMethods(DictuVM *vm) {
     defineNative(vm, &vm->dictMethods, "copy", copyDictShallow);
     defineNative(vm, &vm->dictMethods, "deepCopy", copyDictDeep);
     defineNative(vm, &vm->dictMethods, "toBool", boolNative); // Defined in util
+
+    dictuInterpret(vm, "Dict", DICTU_DICT_SOURCE);
+
+    Value Dict;
+    tableGet(&vm->modules, copyString(vm, "Dict", 4), &Dict);
+
+    ObjModule *DictModule = AS_MODULE(Dict);
+    push(vm, Dict);
+    tableAddAll(vm, &DictModule->values, &vm->dictMethods);
+    pop(vm);
 }

--- a/src/vm/datatypes/dicts/dicts.h
+++ b/src/vm/datatypes/dicts/dicts.h
@@ -5,8 +5,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "copy.h"
-#include "../util.h"
+#include "../copy.h"
+#include "../../util.h"
 
 void declareDictMethods(DictuVM *vm);
 

--- a/src/vm/datatypes/generate.du
+++ b/src/vm/datatypes/generate.du
@@ -27,6 +27,7 @@ def generate(filename) {
 
 var files = [
     'lists/list',
+    'dicts/dict',
     'result/result'
 ];
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -17,7 +17,7 @@
 #include "datatypes/nil.h"
 #include "datatypes/strings.h"
 #include "datatypes/lists/lists.h"
-#include "datatypes/dicts.h"
+#include "datatypes/dicts/dicts.h"
 #include "datatypes/sets.h"
 #include "datatypes/files.h"
 #include "datatypes/class.h"
@@ -501,7 +501,17 @@ static bool invoke(DictuVM *vm, ObjString *name, int argCount) {
             case OBJ_DICT: {
                 Value value;
                 if (tableGet(&vm->dictMethods, name, &value)) {
-                    return callNativeMethod(vm, value, argCount);
+                    if (IS_NATIVE(value)) {
+                        return callNativeMethod(vm, value, argCount);
+                    }
+
+                    push(vm, peek(vm, 0));
+
+                    for (int i = 2; i <= argCount + 1; i++) {
+                        vm->stackTop[-i] = peek(vm, i);
+                    }
+
+                    return call(vm, AS_CLOSURE(value), argCount + 1);
                 }
 
                 runtimeError(vm, "Dict has no method %s().", name->chars);

--- a/tests/dicts/forEach.du
+++ b/tests/dicts/forEach.du
@@ -1,0 +1,27 @@
+/**
+ * forEach.du
+ *
+ * Testing the dict.forEach() method
+ *
+ * .forEach() loops over a dictionary
+ */
+
+const myDict = {"key": 1, "key1": 2, "key2": 3};
+var count = 0;
+
+myDict.forEach(def (key, value) => {
+   count += 1;
+   assert(type(key) == "string");
+   assert(type(value) == "number");
+});
+
+assert(count == 3);
+
+const myNewDict = {1: 1, 2: 2, 3: 3};
+var sum = 0;
+
+myNewDict.forEach(def (key, value) => {
+    sum += key + value;
+});
+
+assert(sum == 12);

--- a/tests/dicts/import.du
+++ b/tests/dicts/import.du
@@ -13,3 +13,4 @@ import "copy.du";
 import "len.du";
 import "toString.du";
 import "toBool.du";
+import "forEach.du";


### PR DESCRIPTION
# dict.forEach()
Resolves #412 
## Summary
This PR adds in `dict.forEach` which makes iterating over a dictionary much nicer. As explained in the issue we would have to iterate over a list of keys and then index back into the dictionary which is a nit nasty.