### PR TITLE
printError

### DIFF
--- a/docs/docs/built-ins.md
+++ b/docs/docs/built-ins.md
@@ -35,6 +35,16 @@ print("test"); // "test"
 print(10, "test", nil, true); // 10, "test", nil, true
 ```
 
+### printError(...values...)
+
+Prints a given list of values to stderr.
+
+```cs
+printError(10); // 10
+printError("test"); // "test"
+printError(10, "test", nil, true); // 10, "test", nil, true
+```
+
 ### input(string: prompt -> optional)
 
 Gathers user input from stdin and returns the value as a string. `input()` has an optional prompt which will be shown to

--- a/src/vm/natives.c
+++ b/src/vm/natives.c
@@ -98,6 +98,22 @@ static Value printNative(DictuVM *vm, int argCount, Value *args) {
     return NIL_VAL;
 }
 
+static Value printErrorNative(DictuVM *vm, int argCount, Value *args) {
+    UNUSED(vm);
+
+    if (argCount == 0) {
+        fprintf(stderr, "\n");
+        return NIL_VAL;
+    }
+
+    for (int i = 0; i < argCount; ++i) {
+        printValueError(args[i]);
+        fprintf(stderr, "\n");
+    }
+
+    return NIL_VAL;
+}
+
 static Value assertNative(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError(vm, "assert() takes 1 argument (%d given)", argCount);
@@ -170,6 +186,7 @@ void defineAllNatives(DictuVM *vm) {
             "type",
             "set",
             "print",
+            "printError",
             "assert",
             "isDefined",
             "Success",
@@ -181,6 +198,7 @@ void defineAllNatives(DictuVM *vm) {
             typeNative,
             setNative,
             printNative,
+            printErrorNative,
             assertNative,
             isDefinedNative,
             generateSuccessResult,

--- a/src/vm/value.c
+++ b/src/vm/value.c
@@ -455,6 +455,12 @@ void printValue(Value value) {
     free(output);
 }
 
+void printValueError(Value value) {
+    char *output = valueToString(value);
+    fprintf(stderr, "%s", output);
+    free(output);
+}
+
 static bool listComparison(Value a, Value b) {
     ObjList *list = AS_LIST(a);
     ObjList *listB = AS_LIST(b);

--- a/src/vm/value.h
+++ b/src/vm/value.h
@@ -107,4 +107,6 @@ char *valueTypeToString(DictuVM *vm, Value value, int *length);
 
 void printValue(Value value);
 
+void printValueError(Value value);
+
 #endif


### PR DESCRIPTION
# printError
## Summary

This PR adds a new `printError()` builtin that is functionally the same as `print()` however it's stream is `stderr` rather than `stdout`.