### PR TITLE
Added string.title() method to return a title cased string

### DIFF
--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -242,3 +242,13 @@ Returns the number of occurrences of a given substring within another string.
 "This documentation".count("Good jokes"); // 0
 "Sooooooooooome characters".count("o"); // 11
 ```
+
+### string.title()
+
+Returns a title cased version of string with first letter of each word capitalized.
+
+```cs
+"dictu language".title(); // Dictu Language
+"this documentation".title(); // This Documentation
+"once upon a time".title(); // Once Upon A Time
+```

--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -465,6 +465,34 @@ static Value countString(DictuVM *vm, int argCount, Value *args) {
     return NUMBER_VAL(count);
 }
 
+static Value titleString(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "lower() takes no arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    ObjString *string = AS_STRING(args[0]);
+    char *temp = ALLOCATE(vm, char, string->length + 1);
+
+    bool convertNext=true;
+
+    for (int i = 0; string->chars[i]; i++) {
+        if(string->chars[i]==' '){
+            convertNext=true;
+        }
+        else if(convertNext){
+            temp[i] = toupper(string->chars[i]);
+            convertNext=false;
+            continue;
+        }
+        temp[i] = tolower(string->chars[i]);
+    }
+
+    temp[string->length] = '\0';
+
+    return OBJ_VAL(takeString(vm, temp, string->length));
+}
+
 void declareStringMethods(DictuVM *vm) {
     defineNative(vm, &vm->stringMethods, "len", lenString);
     defineNative(vm, &vm->stringMethods, "toNumber", toNumberString);
@@ -482,4 +510,5 @@ void declareStringMethods(DictuVM *vm) {
     defineNative(vm, &vm->stringMethods, "strip", stripString);
     defineNative(vm, &vm->stringMethods, "count", countString);
     defineNative(vm, &vm->stringMethods, "toBool", boolNative); // Defined in util
+    defineNative(vm, &vm->stringMethods, "title", titleString);
 }

--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -467,7 +467,7 @@ static Value countString(DictuVM *vm, int argCount, Value *args) {
 
 static Value titleString(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 0) {
-        runtimeError(vm, "lower() takes no arguments (%d given)", argCount);
+        runtimeError(vm, "title() takes no arguments (%d given)", argCount);
         return EMPTY_VAL;
     }
 

--- a/tests/strings/title.du
+++ b/tests/strings/title.du
@@ -1,0 +1,15 @@
+/**
+ * title.du
+ *
+ * Testing the str.title() method
+ *
+ * .title() method returns a string with first letter of each word capitalized; a title cased string.
+ */
+
+assert("title".title() == "Title");
+assert("dictu language".title() == "Dictu Language");
+assert("DiCtU".title() == "Dictu");
+assert("12345".title() == "12345");
+assert("12Dictu45".title() == "12dictu45");
+assert("!@£$%^&*".title() == "!@£$%^&*");
+assert("once upon a time".title()== "Once Upon A Time");


### PR DESCRIPTION
Added New Feature: String utility method called title(), for return a title cased string. 

The title() method returns a string with first letter of each word capitalized; a title cased string.

Updated Docs , and tests are ran successfully .
