### PR TITLE
Remove ubuntu 16 from the workflow and add macos11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
        runs-on: ${{ matrix.os }}
        strategy:
          matrix:
-           os: [ubuntu-latest, ubuntu-16.04, ubuntu-20.04]
+           os: [ubuntu-latest, ubuntu-20.04]
 
        steps:
          - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
        runs-on: ${{ matrix.os }}
        strategy:
          matrix:
-           os: [macOS-latest]
+           os: [macOS-latest, macOS-11]
 
        steps:
          - uses: actions/checkout@v2


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

Updated the github workflow to remove Ubuntu v16 which is now EOL and add in MacOS version 11 (big sur) as macos-latest is still pointing to catalina.

#

### Context of the change :

<!-- Make sure to answer to these questions !-->

Change is required as thee ubuntu 16 pipeline is queued indefinitely.
 
<!-- Link the issue below if you are resolving an issue !-->
 
#

### Type of change :

<!-- Please select relevant options -->

<!-- add a x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

- [ ] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

