### PR TITLE
Strip leading dir separators in `Path.join`

### DIFF
--- a/tests/path/join.du
+++ b/tests/path/join.du
@@ -8,28 +8,46 @@
 import Path;
 
 var result;
-var expected = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg';
+var expected1 = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg';
+var expected2 = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg' + Path.dirSeparator;
+var manyDirSeps = Path.dirSeparator + Path.dirSeparator + Path.dirSeparator + Path.dirSeparator + Path.dirSeparator;
 
 // Test basic join with varargs
 result = Path.join('/tmp', 'abcd', 'efg');
-assert(result == expected);
+assert(result == expected1);
 
 // Test basic join with list
-result = Path.join(['/tmp', 'abcd', 'efg']);
-assert(result == expected);
+result = Path.join(['/tmp', 'abcd', 'efg' + Path.dirSeparator]);
+assert(result == expected2);
 
 // Test join with trailing directory separators with varargs
-result = Path.join('/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator);
-assert(result == expected);
+result = Path.join('/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg');
+assert(result == expected1);
 
 // Test join with trailing directory separators with list
 result = Path.join(['/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator]);
-assert(result == expected);
+assert(result == expected2);
 
 // Test join with leading and trailing directory separators with varargs
-result = Path.join('/tmp' + Path.dirSeparator, Path.dirSeparator + 'abcd' + Path.dirSeparator, Path.dirSeparator + 'efg' + Path.dirSeparator);
-assert(result == expected);
+result = Path.join('/tmp' + Path.dirSeparator, Path.dirSeparator + 'abcd' + Path.dirSeparator, Path.dirSeparator + 'efg');
+assert(result == expected1);
 
 // Test join with leading and trailing directory separators with list
 result = Path.join(['/tmp' + Path.dirSeparator, Path.dirSeparator + 'abcd' + Path.dirSeparator, Path.dirSeparator + 'efg' + Path.dirSeparator]);
-assert(result == expected);
+assert(result == expected2);
+
+// Test join with many leading and trailing directory separators with varargs
+result = Path.join('/tmp' + manyDirSeps, manyDirSeps + 'abcd' + manyDirSeps, manyDirSeps + 'efg');
+assert(result == expected1);
+
+// Test join with many leading and trailing directory separators with list
+result = Path.join(['/tmp' + manyDirSeps, manyDirSeps + 'abcd' + manyDirSeps, manyDirSeps + 'efg' + manyDirSeps]);
+assert(result == expected2);
+
+// Test join with directory separators inside of part with varargs
+result = Path.join('/tmp', 'abcd' + Path.dirSeparator + 'efg');
+assert(result == expected1);
+
+// Test join with directory separators inside of part with list
+result = Path.join(['/tmp', 'abcd' + Path.dirSeparator + 'efg' + Path.dirSeparator]);
+assert(result == expected2);

--- a/tests/path/join.du
+++ b/tests/path/join.du
@@ -7,15 +7,29 @@
  */
 import Path;
 
-assert(Path.join('/tmp', 'abcd', 'efg') == '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg');
-assert(Path.join(['/tmp', 'abcd', 'efg']) == '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg');
+var result;
+var expected = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg';
 
-var a, b;
+// Test basic join with varargs
+result = Path.join('/tmp', 'abcd', 'efg');
+assert(result == expected);
 
-a = Path.join('/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator);
-b = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg';
-assert(a == b);
+// Test basic join with list
+result = Path.join(['/tmp', 'abcd', 'efg']);
+assert(result == expected);
 
-a = Path.join(['/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator]);
-b = '/tmp' + Path.dirSeparator + 'abcd' + Path.dirSeparator + 'efg';
-assert(a == b);
+// Test join with trailing directory separators with varargs
+result = Path.join('/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator);
+assert(result == expected);
+
+// Test join with trailing directory separators with list
+result = Path.join(['/tmp' + Path.dirSeparator, 'abcd' + Path.dirSeparator, 'efg' + Path.dirSeparator]);
+assert(result == expected);
+
+// Test join with leading and trailing directory separators with varargs
+result = Path.join('/tmp' + Path.dirSeparator, Path.dirSeparator + 'abcd' + Path.dirSeparator, Path.dirSeparator + 'efg' + Path.dirSeparator);
+assert(result == expected);
+
+// Test join with leading and trailing directory separators with list
+result = Path.join(['/tmp' + Path.dirSeparator, Path.dirSeparator + 'abcd' + Path.dirSeparator, Path.dirSeparator + 'efg' + Path.dirSeparator]);
+assert(result == expected);


### PR DESCRIPTION
### Well detailed description of the change :

Previously this was the behaviour of `Path.join` with leading directory separators:

```
>>> Path.join('/tmp/', '/abcd/', '/efg/');
/tmp//abcd//efg
```

Now this is the behaviour:

```
>>> Path.join('/tmp/', '/abcd/', '/efg/');
/tmp/abcd/efg
```

### Type of change :

- [X] Bug fix
