### PR TITLE
Allow enums to have a generated value

### DIFF
--- a/docs/docs/enum.md
+++ b/docs/docs/enum.md
@@ -18,17 +18,26 @@ nav_order: 10
 ## Enums
 
 Enums are a collection of constants which can be accessed via a name rather than
-an index to document intent. Unlike other languages, enums in Dictu must be assigned
-to a value when declaring the enum and no automatic value will be generated.
+an index to document intent. Unlike other languages, enums in Dictu do not generate a value
+based on the previous entry, instead if no value is assigned it will be given it's position
+within the enum, 0-based, as a value.
 
 ```cs
-enum Test {
-    a = 0,
-    b = 1,
-    c = 2
+enum MyEnum {
+    a, // 0
+    b, // 1
+    c  // 2
 }
 
-print(Test.a); // 0
+print(MyEnum.a); // 0
+
+enum Test {
+    a = 10, // 10
+    b,      // 1
+    c       // 2
+}
+
+print(Test.a); // 10
 ```
 
 Enums in Dictu also do not care about the value being stored within the enum, so

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -1800,6 +1800,8 @@ static void enumDeclaration(Compiler *compiler) {
 
     consume(compiler, TOKEN_LEFT_BRACE, "Expect '{' before enum body.");
 
+    int index = 0;
+
     do {
         if (check(compiler, TOKEN_RIGHT_BRACE)) {
             error(compiler->parser, "Trailing comma in enum declaration");
@@ -1808,9 +1810,14 @@ static void enumDeclaration(Compiler *compiler) {
         consume(compiler, TOKEN_IDENTIFIER, "Expect enum value identifier.");
         uint8_t name = identifierConstant(compiler, &compiler->parser->previous);
 
-        consume(compiler, TOKEN_EQUAL, "Expect '=' after enum value identifier.");
-        expression(compiler);
+        if (match(compiler, TOKEN_EQUAL)) {
+            expression(compiler);
+        } else {
+            emitConstant(compiler, NUMBER_VAL(index));
+        }
+
         emitBytes(compiler, OP_SET_ENUM_VALUE, name);
+        index++;
     } while (match(compiler, TOKEN_COMMA));
 
     consume(compiler, TOKEN_RIGHT_BRACE, "Expect '}' after enum body.");

--- a/tests/enum/enum.du
+++ b/tests/enum/enum.du
@@ -4,6 +4,16 @@
  * Testing enums
  */
 
+enum MyEnum {
+    a,
+    b,
+    c
+}
+
+assert(MyEnum.a == 0);
+assert(MyEnum.b == 1);
+assert(MyEnum.c == 2);
+
 enum Test {
     a = 1,
     b = 2,
@@ -13,6 +23,18 @@ enum Test {
 assert(Test.a == 1);
 assert(Test.b == 2);
 assert(Test.c == 3);
+
+enum AnotherTest {
+    a,
+    b = "test",
+    c = 30,
+    d
+}
+
+assert(AnotherTest.a == 0);
+assert(AnotherTest.b == "test");
+assert(AnotherTest.c == 30);
+assert(AnotherTest.d == 3);
 
 const func = def () => 10;
 


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

This allows Enums to not always require a user defined value, and instead if the value is omitted its value becomes the index within the Enum.
E.g
```
enum Test {
    a,  // 0
    b,  // 1
    c   //2
}
```

### Type of change :

- [x] New feature

#