### PR TITLE
Require Import for System module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Documentation for Dictu can be found [here](https://dictu-lang.com/)
 
 ## Example programs
 ```js
+import System;
+
 const guess = 10;
 
 while {

--- a/docs/docs/standard-lib/system.md
+++ b/docs/docs/standard-lib/system.md
@@ -17,6 +17,11 @@ parent: Standard Library
 ---
 
 ## System
+To make use of the System module an import is required.
+
+```js
+import System;
+```
 
 ### Constants
 

--- a/examples/factorial.du
+++ b/examples/factorial.du
@@ -1,3 +1,5 @@
+import System;
+
 var amount;
 
 /**

--- a/examples/guessingGame.du
+++ b/examples/guessingGame.du
@@ -1,4 +1,5 @@
 import Random;
+import System;
 
 const guess = 10;
 var maxGuesses = 5;

--- a/src/optionals/optionals.c
+++ b/src/optionals/optionals.c
@@ -12,6 +12,7 @@ BuiltinModules modules[] = {
         {"Hashlib", &createHashlibModule},
         {"Sqlite", &createSqliteModule},
         {"Process", &createProcessModule},
+        {"System", &createSystemModule},
 #ifndef DISABLE_HTTP
         {"HTTP", &createHTTPModule},
 #endif

--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -281,7 +281,7 @@ static Value exitNative(DictuVM *vm, int argCount, Value *args) {
     return EMPTY_VAL; /* satisfy the tcc compiler */
 }
 
-void initArgv(DictuVM *vm, Table *table, int argc, char *argv[]) {
+void initArgv(DictuVM *vm, Table *table, int argc, char **argv) {
     ObjList *list = newList(vm);
     push(vm, OBJ_VAL(list));
 
@@ -346,7 +346,7 @@ void setVersion(DictuVM *vm, Table *table) {
     pop(vm);
 }
 
-void createSystemModule(DictuVM *vm, int argc, char *argv[]) {
+ObjModule *createSystemModule(DictuVM *vm) {
     ObjString *name = copyString(vm, "System", 6);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);
@@ -382,7 +382,7 @@ void createSystemModule(DictuVM *vm, int argc, char *argv[]) {
      */
     if (!vm->repl) {
         // Set argv variable
-        initArgv(vm, &module->values, argc, argv);
+        initArgv(vm, &module->values, vm->argc, vm->argv);
     }
 
     initPlatform(vm, &module->values);
@@ -409,7 +409,8 @@ void createSystemModule(DictuVM *vm, int argc, char *argv[]) {
     defineNativeProperty(vm, &module->values, "R_OK", NUMBER_VAL(R_OK));
 #endif
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
+
+    return module;
 }

--- a/src/optionals/system.h
+++ b/src/optionals/system.h
@@ -24,6 +24,6 @@
 #include "../vm/vm.h"
 #include "../vm/memory.h"
 
-void createSystemModule(DictuVM *vm, int argc, char *argv[]);
+ObjModule *createSystemModule(DictuVM *vm);
 
 #endif //dictu_system_h

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -62,7 +62,7 @@ void runtimeError(DictuVM *vm, const char *format, ...) {
     resetStack(vm);
 }
 
-DictuVM *dictuInitVM(bool repl, int argc, char *argv[]) {
+DictuVM *dictuInitVM(bool repl, int argc, char **argv) {
     DictuVM *vm = malloc(sizeof(*vm));
 
     if (vm == NULL) {
@@ -85,6 +85,8 @@ DictuVM *dictuInitVM(bool repl, int argc, char *argv[]) {
     vm->grayCapacity = 0;
     vm->grayStack = NULL;
     vm->lastModule = NULL;
+    vm->argc = argc;
+    vm->argv = argv;
     initTable(&vm->modules);
     initTable(&vm->globals);
     initTable(&vm->constants);
@@ -125,7 +127,6 @@ DictuVM *dictuInitVM(bool repl, int argc, char *argv[]) {
      * Native classes which are not required to be
      * imported. For imported modules see optionals.c
      */
-    createSystemModule(vm, argc, argv);
     createCModule(vm);
 
     if (vm->repl) {

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -48,6 +48,8 @@ struct _vm {
     int grayCount;
     int grayCapacity;
     Obj **grayStack;
+    int argc;
+    char **argv;
 };
 
 #define OK     0

--- a/tests/builtins/__file__.du
+++ b/tests/builtins/__file__.du
@@ -4,6 +4,7 @@
 * Testing __file__
 */
 import Path;
+import System;
 
 assert(Path.basename(__file__) == "__file__.du");
 if (System.platform == "windows") {

--- a/tests/builtins/type.du
+++ b/tests/builtins/type.du
@@ -5,6 +5,7 @@
 *
 * type() returns the type of a value as a string
 */
+import System;
 
 assert(type(nil) == "nil");
 assert(type(true) == "bool");

--- a/tests/datetime/strptime.du
+++ b/tests/datetime/strptime.du
@@ -5,6 +5,7 @@
  *
  */
 import Datetime;
+import System;
 
 if (System.platform != "windows") {
     // 1577836800 is 1/1/2020 at 12:00 am

--- a/tests/path/isDir.du
+++ b/tests/path/isDir.du
@@ -6,6 +6,7 @@
  * Returns true if the given string is a path to a directory, else false. (Linux only) 
  */
 import Path;
+import System;
 
 if (System.platform != "windows") {
   assert(Path.isDir("/usr/bin") == true);

--- a/tests/path/realpath.du
+++ b/tests/path/realpath.du
@@ -6,6 +6,7 @@
  * Returns the canonicalized absolute pathname or nil on error.
  */
 import Path;
+import System;
 
 if (System.platform != "windows") {
   assert(Path.delimiter == ":");

--- a/tests/process/exec.du
+++ b/tests/process/exec.du
@@ -6,6 +6,7 @@
  * exec() executes a new process and does not wait for a return.
  */
 import Process;
+import System;
 
 if (System.platform == "windows") {
     assert(Process.exec(["cmd.exe", "/c", "dir"]).success());

--- a/tests/process/run.du
+++ b/tests/process/run.du
@@ -6,6 +6,7 @@
  * run() executes a new process and does wait for a return.
  */
 import Process;
+import System;
 
 if (System.platform == "windows") {
     assert(Process.run(["cmd.exe", "/c", "dir"]).success());

--- a/tests/system/access.du
+++ b/tests/system/access.du
@@ -5,6 +5,7 @@
  *
  * access() returns if user has the requested permissions for a file.
  */
+import System;
 
 var
   F_OK = System.F_OK,

--- a/tests/system/clock.du
+++ b/tests/system/clock.du
@@ -5,6 +5,7 @@
  *
  * clock() returns number of clock ticks since the start of the program, useful for benchmarks.
  */
+import System;
 
 assert(type(System.clock()) == 'number');
 assert(System.clock() > 0);

--- a/tests/system/constants.du
+++ b/tests/system/constants.du
@@ -4,6 +4,7 @@
  * Testing the System constants
  *
  */
+import System;
 
 /**
  * argv is a list of all parameters passed to the interpreter.

--- a/tests/system/getCWD.du
+++ b/tests/system/getCWD.du
@@ -5,6 +5,7 @@
  *
  * getCWD() gets the current working directory of the process
  */
+import System;
 
 assert(type(System.getCWD().unwrap()) == 'string');
 assert(System.getCWD().unwrap().len() > 0);

--- a/tests/system/mkdir.du
+++ b/tests/system/mkdir.du
@@ -6,6 +6,7 @@
  * mkdir() creates a new directory with the given permissions
  * rmdir() removes a directory
  */
+import System;
 
 var
   S_IRWXU = System.S_IRWXU,

--- a/tests/system/process.du
+++ b/tests/system/process.du
@@ -6,6 +6,7 @@
  * getpid(), getppid(), getuid(), geteuid(), getgid(), getegid() all return information
  * about the running process.
  */
+import System;
 
 if (System.platform != "windows") {
     assert(type(System.getpid()) == "number");

--- a/tests/system/remove.du
+++ b/tests/system/remove.du
@@ -5,6 +5,7 @@
  *
  * remove() removes a file from the system
  */
+import System;
 
 if (System.platform == 'darwin') {
   var sys_test_remove_file = "sys_test_remove.";

--- a/tests/system/setCWD.du
+++ b/tests/system/setCWD.du
@@ -5,6 +5,7 @@
  *
  * setCWD() sets the current working directory
  */
+import System;
 
 var cwd = System.getCWD().unwrap();
 assert(cwd != nil);

--- a/tests/system/sleep.du
+++ b/tests/system/sleep.du
@@ -5,6 +5,7 @@
  *
  * sleep() pauses execution for a given amount of seconds
  */
+import System;
 
 var start = System.time();
 

--- a/tests/system/time.du
+++ b/tests/system/time.du
@@ -5,6 +5,7 @@
  *
  * time() returns a UNIX timestamp.
  */
+import System;
 
 // Time is also tested within sleep.du
 

--- a/tests/system/version.du
+++ b/tests/system/version.du
@@ -5,6 +5,7 @@
  *
  * version is a dictionary denoting the Dictu version.
  */
+import System;
 
 assert(type(System.version) == "dict");
 assert(System.version.len() == 3);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

This PR makes it so that the `System` module will now require an import.

#

### Context of the change :

<!-- Why is this change required ? !-->

This change was done as all other stdlib modules require an import whereas System currently doesn't. This doesn't really make much sense and may cause issues (and certainly confusion) to users who are attempting to use the module / incorrectly import it.
 
<!-- Link the issue below if you are resolving an issue !-->

Resolves: #456 
 
#

### Type of change :

<!-- Please select relevant options -->

<!-- add a x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#
