### PR TITLE
obj.getAttribute to return bound method rather than function

### DIFF
--- a/src/vm/datatypes/instance.c
+++ b/src/vm/datatypes/instance.c
@@ -66,7 +66,9 @@ static Value getAttribute(DictuVM *vm, int argCount, Value *args) {
     }
 
     if (tableGet(&instance->klass->publicMethods, AS_STRING(key), &value)) {
-        return value;
+        ObjBoundMethod *bound = newBoundMethod(vm, OBJ_VAL(instance), AS_CLOSURE(value));
+
+        return OBJ_VAL(bound);
     }
 
     // Check class for properties


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

This PR changes `obj.getAttribute` so that a bound method is returned rather than a function. This will allow us to pull methods off of a class, store in a variable, and call it later as though we were doing it through the object.

#


### Type of change :

<!-- Please select relevant options -->

<!-- add a x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

