### PR TITLE
Add _class attribute to instances

### DIFF
--- a/docs/docs/classes.md
+++ b/docs/docs/classes.md
@@ -288,7 +288,18 @@ print(Test().someMethod()?.someOtherMethod()); // nil
 
 // If the operand is not nil the method / property must exist  
 print(Test()?.unknownMethod()); // Undefined property 'unknownMethod'.
-``` 
+```
+
+### _class
+
+`_class` is a special attribute that is added to instances so that a reference to the class is kept on objects. This will be
+useful for things like pulling class annotations from an object where it's class may be unknown until runtime.
+
+```cs
+class Test {}
+
+print(Test()._class); // <Cls Test>
+```
 
 ## Class variables
 

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -117,6 +117,12 @@ ObjInstance *newInstance(DictuVM *vm, ObjClass *klass) {
     instance->klass = klass;
     initTable(&instance->publicFields);
     initTable(&instance->privateFields);
+
+    ObjString *classString = copyString(vm, "_class", 6);
+    push(vm, OBJ_VAL(classString));
+    tableSet(vm, &instance->publicFields, classString, OBJ_VAL(klass));
+    pop(vm);
+
     return instance;
 }
 

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -118,9 +118,11 @@ ObjInstance *newInstance(DictuVM *vm, ObjClass *klass) {
     initTable(&instance->publicFields);
     initTable(&instance->privateFields);
 
+    push(vm, OBJ_VAL(instance));
     ObjString *classString = copyString(vm, "_class", 6);
     push(vm, OBJ_VAL(classString));
     tableSet(vm, &instance->publicFields, classString, OBJ_VAL(klass));
+    pop(vm);
     pop(vm);
 
     return instance;

--- a/tests/classes/properties.du
+++ b/tests/classes/properties.du
@@ -42,3 +42,9 @@ assert(obj.getAttribute("y") == 10);
 obj.setAttribute("x", 10);
 assert(obj.hasAttribute("x"));
 assert(obj.getAttribute("x") == 10);
+
+assert(obj._class == Test);
+
+class Inherit < Test {}
+
+assert(Inherit()._class == Inherit);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

This PR adds a new `_class` attribute to all instances when they are created. This will give reference to the class which the object was instantiated from. This will be useful for a number of cases, but one of them being it gives us a way to pull class attributes from an object.

<!-- Link the issue below if you are resolving an issue !-->

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->

- [x] New feature
#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).
