### PR TITLE
Off by one error for methods() method

### DIFF
--- a/src/vm/datatypes/class.c
+++ b/src/vm/datatypes/class.c
@@ -27,7 +27,7 @@ static Value methods(DictuVM *vm, int argCount, Value *args) {
     ObjList *list = newList(vm);
     push(vm, OBJ_VAL(list));
 
-    for (int i = 0; i < klass->publicMethods.capacityMask; ++i) {
+    for (int i = 0; i <= klass->publicMethods.capacityMask; ++i) {
         if (klass->publicMethods.entries[i].key == NULL) {
             continue;
         }

--- a/src/vm/datatypes/instance.c
+++ b/src/vm/datatypes/instance.c
@@ -182,7 +182,7 @@ static Value methods(DictuVM *vm, int argCount, Value *args) {
     ObjList *list = newList(vm);
     push(vm, OBJ_VAL(list));
 
-    for (int i = 0; i < instance->klass->publicMethods.capacityMask; ++i) {
+    for (int i = 0; i <= instance->klass->publicMethods.capacityMask; ++i) {
         if (instance->klass->publicMethods.entries[i].key == NULL) {
             continue;
         }


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

This PR fixes an issue where the loop for `.methods()` is off by one.

<!-- Link the issue below if you are resolving an issue !-->

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).
