### PR TITLE
add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-FIXME.
+[emailing the project team][email].
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -122,6 +122,7 @@ Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
+[email]: mailto:jasonhall96686@gmail.com
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at


### PR DESCRIPTION
### Well detailed description of the change :

Adding standard text of Contributor Covenant to root directory.

Note: the contact details have **not** been filled in (look for `FIXME` in the text). This must be added before the PR is merged.

### Type of change:

- [x] New feature