### PR TITLE
Add optional argument to split

### DIFF
--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -167,9 +167,11 @@ Returns true if a string ends with a given string.
 Returns a list of strings, split based on a given delimiter.
 Returns a list of all characters in a string if an empty string is passed as delimiter.
 
-An optional second argument can be passed which will determine the amount of times a split occurs.
+An optional second argument can be passed which will determine the amount of times a split occurs, if negative it's the same
+as not passing a value and will split by all occurrences of the delimiter.
 ```cs
 "Dictu is awesome!".split(" "); // ['Dictu', 'is', 'awesome!']
+"Dictu is awesome!".split(" ", -1); // ['Dictu', 'is', 'awesome!']
 "Dictu is awesome!".split(""); // ["D", "i", "c", "t", "u", " ", "i", "s", " ", "a", "w", "e", "s", "o", "m", "e", "!"]
 "Dictu is awesome!".split(" ", 0); // ['Dictu is awesome!']
 "Dictu is awesome!".split(" ", 1); // ['Dictu', 'is awesome!']

--- a/docs/docs/strings.md
+++ b/docs/docs/strings.md
@@ -162,13 +162,17 @@ Returns true if a string ends with a given string.
 "Dictu".endsWith("U"); // false
 ```
 
-### string.split(delimiter)
+### string.split(string: delimiter, number: splitCount -> optional)
 
 Returns a list of strings, split based on a given delimiter.
 Returns a list of all characters in a string if an empty string is passed as delimiter.
+
+An optional second argument can be passed which will determine the amount of times a split occurs.
 ```cs
 "Dictu is awesome!".split(" "); // ['Dictu', 'is', 'awesome!']
 "Dictu is awesome!".split(""); // ["D", "i", "c", "t", "u", " ", "i", "s", " ", "a", "w", "e", "s", "o", "m", "e", "!"]
+"Dictu is awesome!".split(" ", 0); // ['Dictu is awesome!']
+"Dictu is awesome!".split(" ", 1); // ['Dictu', 'is awesome!']
 ```
 
 ### string.replace(string: old, string: new)

--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -142,7 +142,9 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
             return EMPTY_VAL;
         }
 
-        maxSplit = AS_NUMBER(args[2]);
+        if (AS_NUMBER(args[2]) >= 0) {
+            maxSplit = AS_NUMBER(args[2]);
+        }
     }
 
     char *tmp = ALLOCATE(vm, char, string->length + 1);
@@ -174,7 +176,7 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
         } else {
             tmp = NULL;
         }
-    } else if (count < maxSplit) {
+    } else if (maxSplit > 0) {
         do {
             count++;
             token = strstr(tmp, delimiter);

--- a/src/vm/datatypes/strings.c
+++ b/src/vm/datatypes/strings.c
@@ -122,8 +122,8 @@ static Value formatString(DictuVM *vm, int argCount, Value *args) {
 }
 
 static Value splitString(DictuVM *vm, int argCount, Value *args) {
-    if (argCount != 1) {
-        runtimeError(vm, "split() takes 1 argument (%d given)", argCount);
+    if (argCount != 1 && argCount != 2) {
+        runtimeError(vm, "split() takes 1 or 2 arguments (%d given)", argCount);
         return EMPTY_VAL;
     }
 
@@ -134,6 +134,16 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
 
     ObjString *string = AS_STRING(args[0]);
     char *delimiter = AS_CSTRING(args[1]);
+    int maxSplit = string->length + 1;
+
+    if (argCount == 2) {
+        if (!AS_NUMBER(args[1])) {
+            runtimeError(vm, "Argument passed to split() must be a number");
+            return EMPTY_VAL;
+        }
+
+        maxSplit = AS_NUMBER(args[2]);
+    }
 
     char *tmp = ALLOCATE(vm, char, string->length + 1);
     char *tmpFree = tmp;
@@ -144,9 +154,13 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
 
     ObjList *list = newList(vm);
     push(vm, OBJ_VAL(list));
+    int count = 0;
+
     if (delimiterLength == 0) {
-        for (int tokenCount = 0; tokenCount < string->length; tokenCount++) {
-            *(tmp) = string->chars[tokenCount];
+        int tokenIndex = 0;
+        for (; tokenIndex < string->length && count < maxSplit; tokenIndex++) {
+            count++;
+            *(tmp) = string->chars[tokenIndex];
             *(tmp + 1) = '\0';
             Value str = OBJ_VAL(copyString(vm, tmp, 1));
             // Push to stack to avoid GC
@@ -154,8 +168,15 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
             writeValueArray(vm, &list->values, str);
             pop(vm);
         }
-    } else {
+
+        if (tokenIndex != string->length && count >= maxSplit) {
+            tmp = (string->chars) + tokenIndex;
+        } else {
+            tmp = NULL;
+        }
+    } else if (count < maxSplit) {
         do {
+            count++;
             token = strstr(tmp, delimiter);
             if (token)
                 *token = '\0';
@@ -168,8 +189,22 @@ static Value splitString(DictuVM *vm, int argCount, Value *args) {
             pop(vm);
 
             tmp = token + delimiterLength;
-        } while (token != NULL);
+        } while (token != NULL && count < maxSplit);
+
+        if (token == NULL) {
+            tmp = NULL;
+        }
     }
+
+    if (tmp != NULL && count >= maxSplit) {
+        Value remainingStr = OBJ_VAL(copyString(vm, tmp, strlen(tmp)));
+
+        // Push to stack to avoid GC
+        push(vm, remainingStr);
+        writeValueArray(vm, &list->values, remainingStr);
+        pop(vm);
+    }
+
     pop(vm);
 
     FREE_ARRAY(vm, char, tmpFree, string->length + 1);

--- a/tests/strings/split.du
+++ b/tests/strings/split.du
@@ -14,3 +14,21 @@ assert("Dictu is great!".split(",") == ["Dictu is great!"]);
 assert("Dictu is great!".split("12345") == ["Dictu is great!"]);
 assert("Dictu is great!".split("!@£$%^") == ["Dictu is great!"]);
 assert("Dictu is great!".split("") == ["D", "i", "c", "t", "u", " ", "i", "s", " ", "g", "r", "e", "a", "t", "!"]);
+
+// Test optional split amount
+assert("Dictu is great!".split(" ", -2) == ["Dictu is great!"]);
+assert("Dictu is great!".split(" ", -1) == ["Dictu is great!"]);
+assert("Dictu is great!".split(" ", 0) == ["Dictu is great!"]);
+assert("Dictu is great!".split(" ", 1) == ["Dictu", "is great!"]);
+assert("Dictu is great!".split(" ", 2) == ["Dictu", "is", "great!"]);
+assert("Dictu is great!".split(" ", 3) == ["Dictu", "is", "great!"]);
+assert("Dictu is great!".split(" ", 4) == ["Dictu", "is", "great!"]);
+
+assert("Dictu is great!".split("", -2) == ["Dictu is great!"]);
+assert("Dictu is great!".split("", -1) == ["Dictu is great!"]);
+assert("Dictu is great!".split("", 0) == ["Dictu is great!"]);
+assert("Dictu is great!".split("", 1) == ["D", "ictu is great!"]);
+assert("Dictu is great!".split("", 2) == ["D", "i", "ctu is great!"]);
+assert("Dictu is great!".split("", 3) == ["D", "i", "c", "tu is great!"]);
+assert("Dictu is great!".split("", 4) == ["D", "i", "c", "t", "u is great!"]);
+

--- a/tests/strings/split.du
+++ b/tests/strings/split.du
@@ -16,16 +16,16 @@ assert("Dictu is great!".split("!@£$%^") == ["Dictu is great!"]);
 assert("Dictu is great!".split("") == ["D", "i", "c", "t", "u", " ", "i", "s", " ", "g", "r", "e", "a", "t", "!"]);
 
 // Test optional split amount
-assert("Dictu is great!".split(" ", -2) == ["Dictu is great!"]);
-assert("Dictu is great!".split(" ", -1) == ["Dictu is great!"]);
+assert("Dictu is great!".split(" ", -2) == ["Dictu", "is", "great!"]);
+assert("Dictu is great!".split(" ", -1) == ["Dictu", "is", "great!"]);
 assert("Dictu is great!".split(" ", 0) == ["Dictu is great!"]);
 assert("Dictu is great!".split(" ", 1) == ["Dictu", "is great!"]);
 assert("Dictu is great!".split(" ", 2) == ["Dictu", "is", "great!"]);
 assert("Dictu is great!".split(" ", 3) == ["Dictu", "is", "great!"]);
 assert("Dictu is great!".split(" ", 4) == ["Dictu", "is", "great!"]);
 
-assert("Dictu is great!".split("", -2) == ["Dictu is great!"]);
-assert("Dictu is great!".split("", -1) == ["Dictu is great!"]);
+assert("Dictu is great!".split("", -2) == ["D", "i", "c", "t", "u", " ", "i", "s", " ", "g", "r", "e", "a", "t", "!"]);
+assert("Dictu is great!".split("", -1) == ["D", "i", "c", "t", "u", " ", "i", "s", " ", "g", "r", "e", "a", "t", "!"]);
 assert("Dictu is great!".split("", 0) == ["Dictu is great!"]);
 assert("Dictu is great!".split("", 1) == ["D", "ictu is great!"]);
 assert("Dictu is great!".split("", 2) == ["D", "i", "ctu is great!"]);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

This PR adds a new optional argument to `str.split()` which determines the amount of times a string will actually be broken up by the delimiter. This allows us to keep the delimiter within the string after a certain amount of occurrences have already been found.

E.g
```
"Dictu is awesome!".split(" ", 0); // ['Dictu is awesome!']
"Dictu is awesome!".split(" ", 1); // ['Dictu', 'is awesome!']
"Dictu is awesome!".split(" ", 2); // ['Dictu', 'is', 'awesome!']
```

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [ ] Bug fix

- [x] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

### Note
This may come in useful with regards to #473  