### PR TITLE
Correctly reset last module after import statement

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -2284,8 +2284,6 @@ static void importStatement(Compiler *compiler) {
             emitByte(compiler, OP_IMPORT_VARIABLE);
             defineVariable(compiler, importName, false);
         }
-
-        emitByte(compiler, OP_IMPORT_END);
     } else {
         consume(compiler, TOKEN_IDENTIFIER, "Expect import identifier.");
         uint8_t importName = identifierConstant(compiler, &compiler->parser->previous);
@@ -2314,6 +2312,7 @@ static void importStatement(Compiler *compiler) {
         defineVariable(compiler, importName, false);
     }
 
+    emitByte(compiler, OP_IMPORT_END);
     consume(compiler, TOKEN_SEMICOLON, "Expect ';' after import.");
 }
 
@@ -2361,8 +2360,6 @@ static void fromImportStatement(Compiler *compiler) {
                 defineVariable(compiler, 0, false);
             }
         }
-
-        emitByte(compiler, OP_IMPORT_END);
     } else {
         consume(compiler, TOKEN_IDENTIFIER, "Expect import identifier.");
         uint8_t importName = identifierConstant(compiler, &compiler->parser->previous);
@@ -2419,6 +2416,7 @@ static void fromImportStatement(Compiler *compiler) {
         }
     }
 
+    emitByte(compiler, OP_IMPORT_END);
     consume(compiler, TOKEN_SEMICOLON, "Expect ';' after import.");
 }
 


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

Correctly set the VM reference to the last module after an import has comlpeted

<!-- Link the issue below if you are resolving an issue !-->

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix
