### PR TITLE
Add assertType method to UnitTest

### DIFF
--- a/docs/docs/standard-lib/unittest.md
+++ b/docs/docs/standard-lib/unittest.md
@@ -415,6 +415,15 @@ This helper method ensures that the value passed in is equal to nil.
 
 This helper method ensures that the value passed in is not equal to nil.
 
+### assertType(value, value)
+
+This helper method checks the type of the first value is equal to the type as a string.
+
+```cs
+this.assertType("Dictu", "string");
+this.assertType(10, "number");
+```
+
 ### assertTruthy(value)
 
 This helper method ensures that the value passed in would evaluate to true.

--- a/src/optionals/unittest/unittest-source.h
+++ b/src/optionals/unittest/unittest-source.h
@@ -102,7 +102,7 @@
 "    }\n" \
 "\n" \
 "    assertNotEquals(value, expected) {\n" \
-"        this.printResult(value == expected, 'Failure: {} is equal to {}.'.format(value, expected));\n" \
+"        this.printResult(value != expected, 'Failure: {} is equal to {}.'.format(value, expected));\n" \
 "    }\n" \
 "\n" \
 "    assertNil(value) {\n" \
@@ -111,6 +111,11 @@
 "\n" \
 "    assertNotNil(value) {\n" \
 "        this.printResult(value != nil, 'Failure: Should not be nil.');\n" \
+"    }\n" \
+"\n" \
+"    assertType(value, expected) {\n" \
+"        const valType = type(value);\n" \
+"        this.printResult(valType == expected, 'Failure: {}({}) is not of type {}.'.format(value, valType, expected));\n" \
 "    }\n" \
 "\n" \
 "    assertTruthy(value) {\n" \

--- a/src/optionals/unittest/unittest.du
+++ b/src/optionals/unittest/unittest.du
@@ -102,7 +102,7 @@ abstract class UnitTest {
     }
 
     assertNotEquals(value, expected) {
-        this.printResult(value == expected, 'Failure: {} is equal to {}.'.format(value, expected));
+        this.printResult(value != expected, 'Failure: {} is equal to {}.'.format(value, expected));
     }
 
     assertNil(value) {
@@ -111,6 +111,11 @@ abstract class UnitTest {
 
     assertNotNil(value) {
         this.printResult(value != nil, 'Failure: Should not be nil.');
+    }
+
+    assertType(value, expected) {
+        const valType = type(value);
+        this.printResult(valType == expected, 'Failure: {}({}) is not of type {}.'.format(value, valType, expected));
     }
 
     assertTruthy(value) {


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

Adds a new helper `assertType(x, y)` which is the same as `assertEquals(type(x), y);`

Also fixes a bug where `assertNotEquals` had the wrong comparison check.

<!-- Link the issue below if you are resolving an issue !-->

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->

- [x] Bug fix

- [x] New feature

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).
