### PR TITLE
Fix a niche issue with global shadowing

### DIFF
--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -1191,8 +1191,9 @@ static void namedVariable(Compiler *compiler, Token name, bool canAssign) {
     } else {
         arg = identifierConstant(compiler, &name);
         ObjString *string = copyString(compiler->parser->vm, name.start, name.length);
-        Value value;
-        if (tableGet(&compiler->parser->vm->globals, string, &value)) {
+        Value _;
+        if (!tableGet(&compiler->function->module->values, string, &_) &&
+        tableGet(&compiler->parser->vm->globals, string, &_)) {
             getOp = OP_GET_GLOBAL;
             canAssign = false;
         } else {


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

This change makes it so that shadowing a builtin in the module level space has the same effect as shadowing a builtin in the local level space. Previously setting a variable with an identifier of a builtin (e.g input) in the module level space would keep the value of the builtin value rather than taking the new value of the variable. Shadowing should be avoided, but this at least keeps the scoping consistent.

<!-- Link the issue below if you are resolving an issue !-->

Resolves: #341 

#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#
