### PR TITLE
Fixed self import Segmentation fault

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1589,7 +1589,7 @@ static DictuInterpretResult run(DictuVM *vm) {
             module->path = dirname(vm, path, strlen(path));
             vm->lastModule = module;
             pop(vm);
-
+            tableSet(vm, &vm->modules, fileName, OBJ_VAL(module));
             push(vm, OBJ_VAL(module));
             ObjFunction *function = compile(vm, module, source);
             pop(vm);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1565,16 +1565,20 @@ static DictuInterpretResult run(DictuVM *vm) {
             ObjString *fileName = READ_STRING();
             Value moduleVal;
 
-            // If we have imported this file already, skip.
-            if (tableGet(&vm->modules, fileName, &moduleVal)) {
-                vm->lastModule = AS_MODULE(moduleVal);
-                push(vm, NIL_VAL);
-                DISPATCH();
-            }
-
             char path[PATH_MAX];
             if (!resolvePath(frame->closure->function->module->path->chars, fileName->chars, path)) {
                 RUNTIME_ERROR("Could not open file \"%s\".", fileName->chars);
+            }
+
+            ObjString *pathObj = copyString(vm, path, strlen(path));
+            push(vm, OBJ_VAL(pathObj));
+
+            // If we have imported this file already, skip.
+            if (tableGet(&vm->modules, pathObj, &moduleVal)) {
+                pop(vm);
+                vm->lastModule = AS_MODULE(moduleVal);
+                push(vm, NIL_VAL);
+                DISPATCH();
             }
 
             char *source = readFile(vm, path);
@@ -1583,13 +1587,10 @@ static DictuInterpretResult run(DictuVM *vm) {
                 RUNTIME_ERROR("Could not open file \"%s\".", fileName->chars);
             }
 
-            ObjString *pathObj = copyString(vm, path, strlen(path));
-            push(vm, OBJ_VAL(pathObj));
             ObjModule *module = newModule(vm, pathObj);
             module->path = dirname(vm, path, strlen(path));
             vm->lastModule = module;
             pop(vm);
-            tableSet(vm, &vm->modules, fileName, OBJ_VAL(module));
             push(vm, OBJ_VAL(module));
             ObjFunction *function = compile(vm, module, source);
             pop(vm);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

   While Importing the same file as a module in the same file we are getting a Segmentation fault.
Ex: if we execute the below code by writing it in test.du file
`import "./test.du";
var x = 1;
print(x);`

<!-- Explain what you have done !-->


<!-- Link the issue below if you are resolving an issue !-->

Resolves: #

  After creating the module we need to add it to vm->modules table to keep it tracked.
#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->
 added below line in vm.c file in IMPORT opcode block
`tableSet(vm, &vm->modules, fileName, OBJ_VAL(module));`

<!-- Delete options that aren't relevant!-->


- [ ] Bug fix

- [ ] New feature

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).

- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Preview (Screenshots) :

<!-- If applicable attempt to explain the screenshots !-->
Before changes

![image](https://user-images.githubusercontent.com/42714264/197350365-d2201daf-6ef2-4299-bc8a-b3f1d2476909.png)

After Change

![image](https://user-images.githubusercontent.com/42714264/197350446-8efad0d7-304d-4501-bd39-fc163fb1508b.png)

