### PR TITLE
Fixed self referencing datatypes bug

### DIFF
--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -9,11 +9,12 @@
 #include "vm.h"
 
 #define ALLOCATE_OBJ(vm, type, objectType) \
-    (type*)allocateObject(vm, sizeof(type), objectType)
+    (type *)allocateObject(vm, sizeof(type), objectType)
 
-static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type) {
+static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type)
+{
     Obj *object;
-    object = (Obj *) reallocate(vm, NULL, 0, size);
+    object = (Obj *)reallocate(vm, NULL, 0, size);
     object->type = type;
     object->isDark = false;
     object->next = vm->objects;
@@ -26,9 +27,11 @@ static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type) {
     return object;
 }
 
-ObjModule *newModule(DictuVM *vm, ObjString *name) {
+ObjModule *newModule(DictuVM *vm, ObjString *name)
+{
     Value moduleVal;
-    if (tableGet(&vm->modules, name, &moduleVal)) {
+    if (tableGet(&vm->modules, name, &moduleVal))
+    {
         return AS_MODULE(moduleVal);
     }
 
@@ -50,7 +53,8 @@ ObjModule *newModule(DictuVM *vm, ObjString *name) {
     return module;
 }
 
-ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method) {
+ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method)
+{
     ObjBoundMethod *bound = ALLOCATE_OBJ(vm, ObjBoundMethod,
                                          OBJ_BOUND_METHOD);
 
@@ -59,7 +63,8 @@ ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method) 
     return bound;
 }
 
-ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType type) {
+ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType type)
+{
     ObjClass *klass = ALLOCATE_OBJ(vm, ObjClass, OBJ_CLASS);
     klass->name = name;
     klass->superclass = superclass;
@@ -81,16 +86,19 @@ ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType
     return klass;
 }
 
-ObjEnum *newEnum(DictuVM *vm, ObjString *name) {
-    ObjEnum *enumObj = ALLOCATE_OBJ(vm, ObjEnum , OBJ_ENUM);
+ObjEnum *newEnum(DictuVM *vm, ObjString *name)
+{
+    ObjEnum *enumObj = ALLOCATE_OBJ(vm, ObjEnum, OBJ_ENUM);
     enumObj->name = name;
     initTable(&enumObj->values);
     return enumObj;
 }
 
-ObjClosure *newClosure(DictuVM *vm, ObjFunction *function) {
-    ObjUpvalue **upvalues = ALLOCATE(vm, ObjUpvalue*, function->upvalueCount);
-    for (int i = 0; i < function->upvalueCount; i++) {
+ObjClosure *newClosure(DictuVM *vm, ObjFunction *function)
+{
+    ObjUpvalue **upvalues = ALLOCATE(vm, ObjUpvalue *, function->upvalueCount);
+    for (int i = 0; i < function->upvalueCount; i++)
+    {
         upvalues[i] = NULL;
     }
 
@@ -101,7 +109,8 @@ ObjClosure *newClosure(DictuVM *vm, ObjFunction *function) {
     return closure;
 }
 
-ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, AccessLevel level) {
+ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, AccessLevel level)
+{
     ObjFunction *function = ALLOCATE_OBJ(vm, ObjFunction, OBJ_FUNCTION);
     function->arity = 0;
     function->arityOptional = 0;
@@ -122,7 +131,8 @@ ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, Acce
     return function;
 }
 
-ObjInstance *newInstance(DictuVM *vm, ObjClass *klass) {
+ObjInstance *newInstance(DictuVM *vm, ObjClass *klass)
+{
     ObjInstance *instance = ALLOCATE_OBJ(vm, ObjInstance, OBJ_INSTANCE);
     instance->klass = klass;
     initTable(&instance->publicFields);
@@ -138,14 +148,16 @@ ObjInstance *newInstance(DictuVM *vm, ObjClass *klass) {
     return instance;
 }
 
-ObjNative *newNative(DictuVM *vm, NativeFn function) {
+ObjNative *newNative(DictuVM *vm, NativeFn function)
+{
     ObjNative *native = ALLOCATE_OBJ(vm, ObjNative, OBJ_NATIVE);
     native->function = function;
     return native;
 }
 
 static ObjString *allocateString(DictuVM *vm, char *chars, int length,
-                                 uint32_t hash) {
+                                 uint32_t hash)
+{
     ObjString *string = ALLOCATE_OBJ(vm, ObjString, OBJ_STRING);
     string->length = length;
     string->chars = chars;
@@ -156,13 +168,15 @@ static ObjString *allocateString(DictuVM *vm, char *chars, int length,
     return string;
 }
 
-ObjList *newList(DictuVM *vm) {
+ObjList *newList(DictuVM *vm)
+{
     ObjList *list = ALLOCATE_OBJ(vm, ObjList, OBJ_LIST);
     initValueArray(&list->values);
     return list;
 }
 
-ObjDict *newDict(DictuVM *vm) {
+ObjDict *newDict(DictuVM *vm)
+{
     ObjDict *dict = ALLOCATE_OBJ(vm, ObjDict, OBJ_DICT);
     dict->count = 0;
     dict->capacityMask = -1;
@@ -170,7 +184,8 @@ ObjDict *newDict(DictuVM *vm) {
     return dict;
 }
 
-ObjSet *newSet(DictuVM *vm) {
+ObjSet *newSet(DictuVM *vm)
+{
     ObjSet *set = ALLOCATE_OBJ(vm, ObjSet, OBJ_SET);
     set->count = 0;
     set->capacityMask = -1;
@@ -178,11 +193,13 @@ ObjSet *newSet(DictuVM *vm) {
     return set;
 }
 
-ObjFile *newFile(DictuVM *vm) {
+ObjFile *newFile(DictuVM *vm)
+{
     return ALLOCATE_OBJ(vm, ObjFile, OBJ_FILE);
 }
 
-ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type) {
+ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type)
+{
     ObjAbstract *abstract = ALLOCATE_OBJ(vm, ObjAbstract, OBJ_ABSTRACT);
     abstract->data = NULL;
     abstract->func = func;
@@ -192,7 +209,8 @@ ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type) 
     return abstract;
 }
 
-ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value) {
+ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value)
+{
     ObjResult *result = ALLOCATE_OBJ(vm, ObjResult, OBJ_RESULT);
     result->status = status;
     result->value = value;
@@ -200,14 +218,16 @@ ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value) {
     return result;
 }
 
-Value newResultSuccess(DictuVM *vm, Value value) {
+Value newResultSuccess(DictuVM *vm, Value value)
+{
     push(vm, value);
     ObjResult *result = newResult(vm, SUCCESS, value);
     pop(vm);
     return OBJ_VAL(result);
 }
 
-Value newResultError(DictuVM *vm, char *errorMsg) {
+Value newResultError(DictuVM *vm, char *errorMsg)
+{
     Value error = OBJ_VAL(copyString(vm, errorMsg, strlen(errorMsg)));
     push(vm, error);
     ObjResult *result = newResult(vm, ERR, error);
@@ -215,10 +235,12 @@ Value newResultError(DictuVM *vm, char *errorMsg) {
     return OBJ_VAL(result);
 }
 
-static uint32_t hashString(const char *key, int length) {
+static uint32_t hashString(const char *key, int length)
+{
     uint32_t hash = 2166136261u;
 
-    for (int i = 0; i < length; i++) {
+    for (int i = 0; i < length; i++)
+    {
         hash ^= key[i];
         hash *= 16777619;
     }
@@ -226,11 +248,13 @@ static uint32_t hashString(const char *key, int length) {
     return hash;
 }
 
-ObjString *takeString(DictuVM *vm, char *chars, int length) {
+ObjString *takeString(DictuVM *vm, char *chars, int length)
+{
     uint32_t hash = hashString(chars, length);
     ObjString *interned = tableFindString(&vm->strings, chars, length,
                                           hash);
-    if (interned != NULL) {
+    if (interned != NULL)
+    {
         FREE_ARRAY(vm, char, chars, length + 1);
         return interned;
     }
@@ -240,11 +264,13 @@ ObjString *takeString(DictuVM *vm, char *chars, int length) {
     return allocateString(vm, chars, length, hash);
 }
 
-ObjString *copyString(DictuVM *vm, const char *chars, int length) {
+ObjString *copyString(DictuVM *vm, const char *chars, int length)
+{
     uint32_t hash = hashString(chars, length);
     ObjString *interned = tableFindString(&vm->strings, chars, length,
                                           hash);
-    if (interned != NULL) return interned;
+    if (interned != NULL)
+        return interned;
 
     char *heapChars = ALLOCATE(vm, char, length + 1);
     memcpy(heapChars, chars, length);
@@ -252,7 +278,8 @@ ObjString *copyString(DictuVM *vm, const char *chars, int length) {
     return allocateString(vm, heapChars, length, hash);
 }
 
-ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot) {
+ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot)
+{
     ObjUpvalue *upvalue = ALLOCATE_OBJ(vm, ObjUpvalue, OBJ_UPVALUE);
     upvalue->closed = NIL_VAL;
     upvalue->value = slot;
@@ -261,38 +288,52 @@ ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot) {
     return upvalue;
 }
 
-char *listToString(Value value) {
+char *listToString(Value value)
+{
     int size = 50;
     ObjList *list = AS_LIST(value);
     char *listString = malloc(sizeof(char) * size);
     memcpy(listString, "[", 1);
     int listStringLength = 1;
 
-    for (int i = 0; i < list->values.count; ++i) {
+    for (int i = 0; i < list->values.count; ++i)
+    {
         Value listValue = list->values.values[i];
 
         char *element;
         int elementSize;
-
-        if (IS_STRING(listValue)) {
+        if (listValue == value)
+        {
+            element = "[...]";
+            elementSize = 5;
+        }
+        else if (IS_STRING(listValue))
+        {
             ObjString *s = AS_STRING(listValue);
             element = s->chars;
             elementSize = s->length;
-        } else {
+        }
+        else
+        {
             element = valueToString(listValue);
             elementSize = strlen(element);
         }
 
-        if (elementSize > (size - listStringLength - 6)) {
-            if (elementSize > size) {
+        if (elementSize > (size - listStringLength - 6))
+        {
+            if (elementSize > size)
+            {
                 size = size + elementSize * 2 + 6;
-            } else {
+            }
+            else
+            {
                 size = size * 2 + 6;
             }
 
             char *newB = realloc(listString, sizeof(char) * size);
 
-            if (newB == NULL) {
+            if (newB == NULL)
+            {
                 printf("Unable to allocate memory\n");
                 exit(71);
             }
@@ -300,18 +341,27 @@ char *listToString(Value value) {
             listString = newB;
         }
 
-        if (IS_STRING(listValue)) {
+        if (listValue == value)
+        {
+            memcpy(listString + listStringLength, element, elementSize);
+            listStringLength += elementSize;
+        }
+        else if (IS_STRING(listValue))
+        {
             memcpy(listString + listStringLength, "\"", 1);
             memcpy(listString + listStringLength + 1, element, elementSize);
             memcpy(listString + listStringLength + 1 + elementSize, "\"", 1);
             listStringLength += elementSize + 2;
-        } else {
+        }
+        else
+        {
             memcpy(listString + listStringLength, element, elementSize);
             listStringLength += elementSize;
             free(element);
         }
 
-        if (i != list->values.count - 1) {
+        if (i != list->values.count - 1)
+        {
             memcpy(listString + listStringLength, ", ", 2);
             listStringLength += 2;
         }
@@ -323,116 +373,152 @@ char *listToString(Value value) {
     return listString;
 }
 
-char *dictToString(Value value) {
-   int count = 0;
-   int size = 50;
-   ObjDict *dict = AS_DICT(value);
-   char *dictString = malloc(sizeof(char) * size);
-   memcpy(dictString, "{", 1);
-   int dictStringLength = 1;
+char *dictToString(Value value)
+{
+    int count = 0;
+    int size = 50;
+    ObjDict *dict = AS_DICT(value);
+    char *dictString = malloc(sizeof(char) * size);
+    memcpy(dictString, "{", 1);
+    int dictStringLength = 1;
 
-   for (int i = 0; i <= dict->capacityMask; ++i) {
-       DictItem *item = &dict->entries[i];
-       if (IS_EMPTY(item->key)) {
-           continue;
-       }
+    for (int i = 0; i <= dict->capacityMask; ++i)
+    {
+        DictItem *item = &dict->entries[i];
+        if (IS_EMPTY(item->key))
+        {
+            continue;
+        }
 
-       count++;
+        count++;
 
-       char *key;
-       int keySize;
+        char *key;
+        int keySize;
 
-       if (IS_STRING(item->key)) {
-           ObjString *s = AS_STRING(item->key);
-           key = s->chars;
-           keySize = s->length;
-       } else {
-           key = valueToString(item->key);
-           keySize = strlen(key);
-       }
+        if (IS_STRING(item->key))
+        {
+            ObjString *s = AS_STRING(item->key);
+            key = s->chars;
+            keySize = s->length;
+        }
+        else
+        {
+            key = valueToString(item->key);
+            keySize = strlen(key);
+        }
 
-       if (keySize > (size - dictStringLength - keySize - 4)) {
-           if (keySize > size) {
-               size += keySize * 2 + 4;
-           } else {
-               size *= 2 + 4;
-           }
+        if (keySize > (size - dictStringLength - keySize - 4))
+        {
+            if (keySize > size)
+            {
+                size += keySize * 2 + 4;
+            }
+            else
+            {
+                size *= 2 + 4;
+            }
 
-           char *newB = realloc(dictString, sizeof(char) * size);
+            char *newB = realloc(dictString, sizeof(char) * size);
 
-           if (newB == NULL) {
-               printf("Unable to allocate memory\n");
-               exit(71);
-           }
+            if (newB == NULL)
+            {
+                printf("Unable to allocate memory\n");
+                exit(71);
+            }
 
-           dictString = newB;
-       }
+            dictString = newB;
+        }
 
-       if (IS_STRING(item->key)) {
-           memcpy(dictString + dictStringLength, "\"", 1);
-           memcpy(dictString + dictStringLength + 1, key, keySize);
-           memcpy(dictString + dictStringLength + 1 + keySize, "\": ", 3);
-           dictStringLength += 4 + keySize;
-       } else {
-           memcpy(dictString + dictStringLength, key, keySize);
-           memcpy(dictString + dictStringLength + keySize, ": ", 2);
-           dictStringLength += 2 + keySize;
-           free(key);
-       }
+        if (IS_STRING(item->key))
+        {
+            memcpy(dictString + dictStringLength, "\"", 1);
+            memcpy(dictString + dictStringLength + 1, key, keySize);
+            memcpy(dictString + dictStringLength + 1 + keySize, "\": ", 3);
+            dictStringLength += 4 + keySize;
+        }
+        else
+        {
+            memcpy(dictString + dictStringLength, key, keySize);
+            memcpy(dictString + dictStringLength + keySize, ": ", 2);
+            dictStringLength += 2 + keySize;
+            free(key);
+        }
 
-       char *element;
-       int elementSize;
+        char *element;
+        int elementSize;
 
-       if (IS_STRING(item->value)) {
-           ObjString *s = AS_STRING(item->value);
-           element = s->chars;
-           elementSize = s->length;
-       } else {
-           element = valueToString(item->value);
-           elementSize = strlen(element);
-       }
+        if (item->value == value)
+        {
+            element = "{...}";
+            elementSize = 5;
+        }
+        else if (IS_STRING(item->value))
+        {
+            ObjString *s = AS_STRING(item->value);
+            element = s->chars;
+            elementSize = s->length;
+        }
+        else
+        {
+            element = valueToString(item->value);
+            elementSize = strlen(element);
+        }
 
-       if (elementSize > (size - dictStringLength - elementSize - 6)) {
-           if (elementSize > size) {
-               size += elementSize * 2 + 6;
-           } else {
-               size = size * 2 + 6;
-           }
+        if (elementSize > (size - dictStringLength - elementSize - 6))
+        {
+            if (elementSize > size)
+            {
+                size += elementSize * 2 + 6;
+            }
+            else
+            {
+                size = size * 2 + 6;
+            }
 
-           char *newB = realloc(dictString, sizeof(char) * size);
+            char *newB = realloc(dictString, sizeof(char) * size);
 
-           if (newB == NULL) {
-               printf("Unable to allocate memory\n");
-               exit(71);
-           }
+            if (newB == NULL)
+            {
+                printf("Unable to allocate memory\n");
+                exit(71);
+            }
 
-           dictString = newB;
-       }
+            dictString = newB;
+        }
+        if (item->value == value)
+        {
+            memcpy(dictString + dictStringLength, element, elementSize);
+            dictStringLength += elementSize;
+        }
+        else if (IS_STRING(item->value))
+        {
+            memcpy(dictString + dictStringLength, "\"", 1);
+            memcpy(dictString + dictStringLength + 1, element, elementSize);
+            memcpy(dictString + dictStringLength + 1 + elementSize, "\"", 1);
+            dictStringLength += 2 + elementSize;
+        }
+        else
+        {
+            memcpy(dictString + dictStringLength, element, elementSize);
+            dictStringLength += elementSize;
+            free(element);
+        }
 
-       if (IS_STRING(item->value)) {
-           memcpy(dictString + dictStringLength, "\"", 1);
-           memcpy(dictString + dictStringLength + 1, element, elementSize);
-           memcpy(dictString + dictStringLength + 1 + elementSize, "\"", 1);
-           dictStringLength += 2 + elementSize;
-       } else {
-           memcpy(dictString + dictStringLength, element, elementSize);
-           dictStringLength += elementSize;
-           free(element);
-       }
+        if (count != dict->count)
+        {
+            memcpy(dictString + dictStringLength, ", ", 2);
+            dictStringLength += 2;
+        }
+    }
 
-       if (count != dict->count) {
-           memcpy(dictString + dictStringLength, ", ", 2);
-           dictStringLength += 2;
-       }
-   }
+    memcpy(dictString + dictStringLength, "}", 1);
+    dictString[dictStringLength + 1] = '\0';
 
-   memcpy(dictString + dictStringLength, "}", 1);
-   dictString[dictStringLength + 1] = '\0';
-
-   return dictString;
+    return dictString;
 }
 
-char *setToString(Value value) {
+char *setToString(Value value)
+{
     int count = 0;
     int size = 50;
     ObjSet *set = AS_SET(value);
@@ -440,7 +526,8 @@ char *setToString(Value value) {
     memcpy(setString, "{", 1);
     int setStringLength = 1;
 
-    for (int i = 0; i <= set->capacityMask; ++i) {
+    for (int i = 0; i <= set->capacityMask; ++i)
+    {
         SetItem *item = &set->entries[i];
         if (IS_EMPTY(item->value) || item->deleted)
             continue;
@@ -450,25 +537,33 @@ char *setToString(Value value) {
         char *element;
         int elementSize;
 
-        if (IS_STRING(item->value)) {
+        if (IS_STRING(item->value))
+        {
             ObjString *s = AS_STRING(item->value);
             element = s->chars;
             elementSize = s->length;
-        } else {
+        }
+        else
+        {
             element = valueToString(item->value);
             elementSize = strlen(element);
         }
 
-        if (elementSize > (size - setStringLength - 5)) {
-            if (elementSize > size * 2) {
+        if (elementSize > (size - setStringLength - 5))
+        {
+            if (elementSize > size * 2)
+            {
                 size += elementSize * 2 + 5;
-            } else {
+            }
+            else
+            {
                 size = size * 2 + 5;
             }
 
             char *newB = realloc(setString, sizeof(char) * size);
 
-            if (newB == NULL) {
+            if (newB == NULL)
+            {
                 printf("Unable to allocate memory\n");
                 exit(71);
             }
@@ -476,19 +571,22 @@ char *setToString(Value value) {
             setString = newB;
         }
 
-
-        if (IS_STRING(item->value)) {
+        if (IS_STRING(item->value))
+        {
             memcpy(setString + setStringLength, "\"", 1);
             memcpy(setString + setStringLength + 1, element, elementSize);
             memcpy(setString + setStringLength + 1 + elementSize, "\"", 1);
             setStringLength += 2 + elementSize;
-        } else {
+        }
+        else
+        {
             memcpy(setString + setStringLength, element, elementSize);
             setStringLength += elementSize;
             free(element);
         }
 
-        if (count != set->count) {
+        if (count != set->count)
+        {
             memcpy(setString + setStringLength, ", ", 2);
             setStringLength += 2;
         }
@@ -500,7 +598,8 @@ char *setToString(Value value) {
     return setString;
 }
 
-char *classToString(Value value) {
+char *classToString(Value value)
+{
     ObjClass *klass = AS_CLASS(value);
     char *classString = malloc(sizeof(char) * (klass->name->length + 7));
     memcpy(classString, "<Cls ", 5);
@@ -510,7 +609,8 @@ char *classToString(Value value) {
     return classString;
 }
 
-char *instanceToString(Value value) {
+char *instanceToString(Value value)
+{
     ObjInstance *instance = AS_INSTANCE(value);
     char *instanceString = malloc(sizeof(char) * (instance->klass->name->length + 12));
     memcpy(instanceString, "<", 1);
@@ -520,172 +620,207 @@ char *instanceToString(Value value) {
     return instanceString;
 }
 
-char *objectToString(Value value) {
-    switch (OBJ_TYPE(value)) {
-        case OBJ_MODULE: {
-            ObjModule *module = AS_MODULE(value);
-            char *moduleString = malloc(sizeof(char) * (module->name->length + 11));
-            snprintf(moduleString, (module->name->length + 10), "<Module %s>", module->name->chars);
-            return moduleString;
+char *objectToString(Value value)
+{
+    switch (OBJ_TYPE(value))
+    {
+    case OBJ_MODULE:
+    {
+        ObjModule *module = AS_MODULE(value);
+        char *moduleString = malloc(sizeof(char) * (module->name->length + 11));
+        snprintf(moduleString, (module->name->length + 10), "<Module %s>", module->name->chars);
+        return moduleString;
+    }
+
+    case OBJ_CLASS:
+    {
+        if (IS_TRAIT(value))
+        {
+            ObjClass *trait = AS_CLASS(value);
+            char *traitString = malloc(sizeof(char) * (trait->name->length + 10));
+            snprintf(traitString, trait->name->length + 9, "<Trait %s>", trait->name->chars);
+            return traitString;
         }
 
-        case OBJ_CLASS: {
-            if (IS_TRAIT(value)) {
-                ObjClass *trait = AS_CLASS(value);
-                char *traitString = malloc(sizeof(char) * (trait->name->length + 10));
-                snprintf(traitString, trait->name->length + 9, "<Trait %s>", trait->name->chars);
-                return traitString;
+        return classToString(value);
+    }
+
+    case OBJ_ENUM:
+    {
+        ObjEnum *enumObj = AS_ENUM(value);
+        char *enumString = malloc(sizeof(char) * (enumObj->name->length + 8));
+        memcpy(enumString, "<Enum ", 6);
+        memcpy(enumString + 6, enumObj->name->chars, enumObj->name->length);
+        memcpy(enumString + 6 + enumObj->name->length, ">", 1);
+
+        enumString[7 + enumObj->name->length] = '\0';
+
+        return enumString;
+    }
+
+    case OBJ_BOUND_METHOD:
+    {
+        ObjBoundMethod *method = AS_BOUND_METHOD(value);
+        char *methodString;
+
+        if (method->method->function->name != NULL)
+        {
+            switch (method->method->function->type)
+            {
+            case TYPE_STATIC:
+            {
+                methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
+                snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
+                break;
             }
 
-            return classToString(value);
+            default:
+            {
+                methodString = malloc(sizeof(char) * (method->method->function->name->length + 16));
+                snprintf(methodString, method->method->function->name->length + 16, "<Bound Method %s>", method->method->function->name->chars);
+                break;
+            }
+            }
         }
-
-        case OBJ_ENUM: {
-            ObjEnum *enumObj = AS_ENUM(value);
-            char *enumString = malloc(sizeof(char) * (enumObj->name->length + 8));
-            memcpy(enumString, "<Enum ", 6);
-            memcpy(enumString + 6, enumObj->name->chars, enumObj->name->length);
-            memcpy(enumString + 6 + enumObj->name->length, ">", 1);
-
-            enumString[7 + enumObj->name->length] = '\0';
-
-            return enumString;
-        }
-
-        case OBJ_BOUND_METHOD: {
-            ObjBoundMethod *method = AS_BOUND_METHOD(value);
-            char *methodString;
-
-            if (method->method->function->name != NULL) {
-                switch (method->method->function->type) {
-                    case TYPE_STATIC: {
-                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
-                        snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
-                        break;
-                    }
-
-                    default: {
-                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 16));
-                        snprintf(methodString, method->method->function->name->length + 16, "<Bound Method %s>", method->method->function->name->chars);
-                        break;
-                    }
-                }
-            } else {
-                switch (method->method->function->type) {
-                    case TYPE_STATIC: {
-                        methodString = malloc(sizeof(char) * 16);
-                        memcpy(methodString, "<Static Method>", 15);
-                        methodString[15] = '\0';
-                        break;
-                    }
-
-                    default: {
-                        methodString = malloc(sizeof(char) * 15);
-                        memcpy(methodString, "<Bound Method>", 14);
-                        methodString[14] = '\0';
-                        break;
-                    }
-                }
+        else
+        {
+            switch (method->method->function->type)
+            {
+            case TYPE_STATIC:
+            {
+                methodString = malloc(sizeof(char) * 16);
+                memcpy(methodString, "<Static Method>", 15);
+                methodString[15] = '\0';
+                break;
             }
 
-            return methodString;
-        }
-
-        case OBJ_CLOSURE: {
-            ObjClosure *closure = AS_CLOSURE(value);
-            char *closureString;
-
-            if (closure->function->name != NULL) {
-                closureString = malloc(sizeof(char) * (closure->function->name->length + 6));
-                snprintf(closureString, closure->function->name->length + 6, "<fn %s>", closure->function->name->chars);
-            } else {
-                closureString = malloc(sizeof(char) * 9);
-                memcpy(closureString, "<Script>", 8);
-                closureString[8] = '\0';
+            default:
+            {
+                methodString = malloc(sizeof(char) * 15);
+                memcpy(methodString, "<Bound Method>", 14);
+                methodString[14] = '\0';
+                break;
             }
-
-            return closureString;
-        }
-
-        case OBJ_FUNCTION: {
-            ObjFunction *function = AS_FUNCTION(value);
-            char *functionString;
-
-            if (function->name != NULL) {
-                functionString = malloc(sizeof(char) * (function->name->length + 6));
-                snprintf(functionString, function->name->length + 6, "<fn %s>", function->name->chars);
-            } else {
-                functionString = malloc(sizeof(char) * 5);
-                memcpy(functionString, "<fn>", 4);
-                functionString[4] = '\0';
             }
-
-            return functionString;
         }
 
-        case OBJ_INSTANCE: {
-            return instanceToString(value);
+        return methodString;
+    }
+
+    case OBJ_CLOSURE:
+    {
+        ObjClosure *closure = AS_CLOSURE(value);
+        char *closureString;
+
+        if (closure->function->name != NULL)
+        {
+            closureString = malloc(sizeof(char) * (closure->function->name->length + 6));
+            snprintf(closureString, closure->function->name->length + 6, "<fn %s>", closure->function->name->chars);
+        }
+        else
+        {
+            closureString = malloc(sizeof(char) * 9);
+            memcpy(closureString, "<Script>", 8);
+            closureString[8] = '\0';
         }
 
-        case OBJ_NATIVE: {
-            char *nativeString = malloc(sizeof(char) * 12);
-            memcpy(nativeString, "<fn native>", 11);
-            nativeString[11] = '\0';
-            return nativeString;
+        return closureString;
+    }
+
+    case OBJ_FUNCTION:
+    {
+        ObjFunction *function = AS_FUNCTION(value);
+        char *functionString;
+
+        if (function->name != NULL)
+        {
+            functionString = malloc(sizeof(char) * (function->name->length + 6));
+            snprintf(functionString, function->name->length + 6, "<fn %s>", function->name->chars);
+        }
+        else
+        {
+            functionString = malloc(sizeof(char) * 5);
+            memcpy(functionString, "<fn>", 4);
+            functionString[4] = '\0';
         }
 
-        case OBJ_STRING: {
-            ObjString *stringObj = AS_STRING(value);
-            char *string = malloc(sizeof(char) * stringObj->length + 1);
-            memcpy(string, stringObj->chars, stringObj->length);
-            string[stringObj->length] = '\0';
-            return string;
-        }
+        return functionString;
+    }
 
-        case OBJ_FILE: {
-            ObjFile *file = AS_FILE(value);
-            char *fileString = malloc(sizeof(char) * (strlen(file->path) + 8));
-            snprintf(fileString, strlen(file->path) + 8, "<File %s>", file->path);
-            return fileString;
-        }
+    case OBJ_INSTANCE:
+    {
+        return instanceToString(value);
+    }
 
-        case OBJ_LIST: {
-            return listToString(value);
-        }
+    case OBJ_NATIVE:
+    {
+        char *nativeString = malloc(sizeof(char) * 12);
+        memcpy(nativeString, "<fn native>", 11);
+        nativeString[11] = '\0';
+        return nativeString;
+    }
 
-        case OBJ_DICT: {
-            return dictToString(value);
-        }
+    case OBJ_STRING:
+    {
+        ObjString *stringObj = AS_STRING(value);
+        char *string = malloc(sizeof(char) * stringObj->length + 1);
+        memcpy(string, stringObj->chars, stringObj->length);
+        string[stringObj->length] = '\0';
+        return string;
+    }
 
-        case OBJ_SET: {
-            return setToString(value);
-        }
+    case OBJ_FILE:
+    {
+        ObjFile *file = AS_FILE(value);
+        char *fileString = malloc(sizeof(char) * (strlen(file->path) + 8));
+        snprintf(fileString, strlen(file->path) + 8, "<File %s>", file->path);
+        return fileString;
+    }
 
-        case OBJ_UPVALUE: {
-            char *upvalueString = malloc(sizeof(char) * 8);
-            memcpy(upvalueString, "upvalue", 7);
-            upvalueString[7] = '\0';
-            return upvalueString;
-        }
+    case OBJ_LIST:
+    {
+        return listToString(value);
+    }
 
-        case OBJ_ABSTRACT: {
-            ObjAbstract *abstract = AS_ABSTRACT(value);
+    case OBJ_DICT:
+    {
+        return dictToString(value);
+    }
 
-            return abstract->type(abstract);
-        }
+    case OBJ_SET:
+    {
+        return setToString(value);
+    }
 
-        case OBJ_RESULT: {
-            ObjResult *result = AS_RESULT(value);
-            if (result->status == SUCCESS) {
-                char *resultString = malloc(sizeof(char) * 13);
-                snprintf(resultString, 13, "<Result Suc>");
-                return resultString;
-            }
+    case OBJ_UPVALUE:
+    {
+        char *upvalueString = malloc(sizeof(char) * 8);
+        memcpy(upvalueString, "upvalue", 7);
+        upvalueString[7] = '\0';
+        return upvalueString;
+    }
 
+    case OBJ_ABSTRACT:
+    {
+        ObjAbstract *abstract = AS_ABSTRACT(value);
+
+        return abstract->type(abstract);
+    }
+
+    case OBJ_RESULT:
+    {
+        ObjResult *result = AS_RESULT(value);
+        if (result->status == SUCCESS)
+        {
             char *resultString = malloc(sizeof(char) * 13);
-            snprintf(resultString, 13, "<Result Err>");
+            snprintf(resultString, 13, "<Result Suc>");
             return resultString;
         }
+
+        char *resultString = malloc(sizeof(char) * 13);
+        snprintf(resultString, 13, "<Result Err>");
+        return resultString;
+    }
     }
 
     char *unknown = malloc(sizeof(char) * 9);

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -9,12 +9,11 @@
 #include "vm.h"
 
 #define ALLOCATE_OBJ(vm, type, objectType) \
-    (type *)allocateObject(vm, sizeof(type), objectType)
+    (type*)allocateObject(vm, sizeof(type), objectType)
 
-static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type)
-{
+static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type) {
     Obj *object;
-    object = (Obj *)reallocate(vm, NULL, 0, size);
+    object = (Obj *) reallocate(vm, NULL, 0, size);
     object->type = type;
     object->isDark = false;
     object->next = vm->objects;
@@ -27,11 +26,9 @@ static Obj *allocateObject(DictuVM *vm, size_t size, ObjType type)
     return object;
 }
 
-ObjModule *newModule(DictuVM *vm, ObjString *name)
-{
+ObjModule *newModule(DictuVM *vm, ObjString *name) {
     Value moduleVal;
-    if (tableGet(&vm->modules, name, &moduleVal))
-    {
+    if (tableGet(&vm->modules, name, &moduleVal)) {
         return AS_MODULE(moduleVal);
     }
 
@@ -53,8 +50,7 @@ ObjModule *newModule(DictuVM *vm, ObjString *name)
     return module;
 }
 
-ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method)
-{
+ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method) {
     ObjBoundMethod *bound = ALLOCATE_OBJ(vm, ObjBoundMethod,
                                          OBJ_BOUND_METHOD);
 
@@ -63,8 +59,7 @@ ObjBoundMethod *newBoundMethod(DictuVM *vm, Value receiver, ObjClosure *method)
     return bound;
 }
 
-ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType type)
-{
+ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType type) {
     ObjClass *klass = ALLOCATE_OBJ(vm, ObjClass, OBJ_CLASS);
     klass->name = name;
     klass->superclass = superclass;
@@ -86,19 +81,16 @@ ObjClass *newClass(DictuVM *vm, ObjString *name, ObjClass *superclass, ClassType
     return klass;
 }
 
-ObjEnum *newEnum(DictuVM *vm, ObjString *name)
-{
-    ObjEnum *enumObj = ALLOCATE_OBJ(vm, ObjEnum, OBJ_ENUM);
+ObjEnum *newEnum(DictuVM *vm, ObjString *name) {
+    ObjEnum *enumObj = ALLOCATE_OBJ(vm, ObjEnum , OBJ_ENUM);
     enumObj->name = name;
     initTable(&enumObj->values);
     return enumObj;
 }
 
-ObjClosure *newClosure(DictuVM *vm, ObjFunction *function)
-{
-    ObjUpvalue **upvalues = ALLOCATE(vm, ObjUpvalue *, function->upvalueCount);
-    for (int i = 0; i < function->upvalueCount; i++)
-    {
+ObjClosure *newClosure(DictuVM *vm, ObjFunction *function) {
+    ObjUpvalue **upvalues = ALLOCATE(vm, ObjUpvalue*, function->upvalueCount);
+    for (int i = 0; i < function->upvalueCount; i++) {
         upvalues[i] = NULL;
     }
 
@@ -109,8 +101,7 @@ ObjClosure *newClosure(DictuVM *vm, ObjFunction *function)
     return closure;
 }
 
-ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, AccessLevel level)
-{
+ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, AccessLevel level) {
     ObjFunction *function = ALLOCATE_OBJ(vm, ObjFunction, OBJ_FUNCTION);
     function->arity = 0;
     function->arityOptional = 0;
@@ -131,8 +122,7 @@ ObjFunction *newFunction(DictuVM *vm, ObjModule *module, FunctionType type, Acce
     return function;
 }
 
-ObjInstance *newInstance(DictuVM *vm, ObjClass *klass)
-{
+ObjInstance *newInstance(DictuVM *vm, ObjClass *klass) {
     ObjInstance *instance = ALLOCATE_OBJ(vm, ObjInstance, OBJ_INSTANCE);
     instance->klass = klass;
     initTable(&instance->publicFields);
@@ -148,16 +138,14 @@ ObjInstance *newInstance(DictuVM *vm, ObjClass *klass)
     return instance;
 }
 
-ObjNative *newNative(DictuVM *vm, NativeFn function)
-{
+ObjNative *newNative(DictuVM *vm, NativeFn function) {
     ObjNative *native = ALLOCATE_OBJ(vm, ObjNative, OBJ_NATIVE);
     native->function = function;
     return native;
 }
 
 static ObjString *allocateString(DictuVM *vm, char *chars, int length,
-                                 uint32_t hash)
-{
+                                 uint32_t hash) {
     ObjString *string = ALLOCATE_OBJ(vm, ObjString, OBJ_STRING);
     string->length = length;
     string->chars = chars;
@@ -168,15 +156,13 @@ static ObjString *allocateString(DictuVM *vm, char *chars, int length,
     return string;
 }
 
-ObjList *newList(DictuVM *vm)
-{
+ObjList *newList(DictuVM *vm) {
     ObjList *list = ALLOCATE_OBJ(vm, ObjList, OBJ_LIST);
     initValueArray(&list->values);
     return list;
 }
 
-ObjDict *newDict(DictuVM *vm)
-{
+ObjDict *newDict(DictuVM *vm) {
     ObjDict *dict = ALLOCATE_OBJ(vm, ObjDict, OBJ_DICT);
     dict->count = 0;
     dict->capacityMask = -1;
@@ -184,8 +170,7 @@ ObjDict *newDict(DictuVM *vm)
     return dict;
 }
 
-ObjSet *newSet(DictuVM *vm)
-{
+ObjSet *newSet(DictuVM *vm) {
     ObjSet *set = ALLOCATE_OBJ(vm, ObjSet, OBJ_SET);
     set->count = 0;
     set->capacityMask = -1;
@@ -193,13 +178,11 @@ ObjSet *newSet(DictuVM *vm)
     return set;
 }
 
-ObjFile *newFile(DictuVM *vm)
-{
+ObjFile *newFile(DictuVM *vm) {
     return ALLOCATE_OBJ(vm, ObjFile, OBJ_FILE);
 }
 
-ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type)
-{
+ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type) {
     ObjAbstract *abstract = ALLOCATE_OBJ(vm, ObjAbstract, OBJ_ABSTRACT);
     abstract->data = NULL;
     abstract->func = func;
@@ -209,8 +192,7 @@ ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type)
     return abstract;
 }
 
-ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value)
-{
+ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value) {
     ObjResult *result = ALLOCATE_OBJ(vm, ObjResult, OBJ_RESULT);
     result->status = status;
     result->value = value;
@@ -218,16 +200,14 @@ ObjResult *newResult(DictuVM *vm, ResultStatus status, Value value)
     return result;
 }
 
-Value newResultSuccess(DictuVM *vm, Value value)
-{
+Value newResultSuccess(DictuVM *vm, Value value) {
     push(vm, value);
     ObjResult *result = newResult(vm, SUCCESS, value);
     pop(vm);
     return OBJ_VAL(result);
 }
 
-Value newResultError(DictuVM *vm, char *errorMsg)
-{
+Value newResultError(DictuVM *vm, char *errorMsg) {
     Value error = OBJ_VAL(copyString(vm, errorMsg, strlen(errorMsg)));
     push(vm, error);
     ObjResult *result = newResult(vm, ERR, error);
@@ -235,12 +215,10 @@ Value newResultError(DictuVM *vm, char *errorMsg)
     return OBJ_VAL(result);
 }
 
-static uint32_t hashString(const char *key, int length)
-{
+static uint32_t hashString(const char *key, int length) {
     uint32_t hash = 2166136261u;
 
-    for (int i = 0; i < length; i++)
-    {
+    for (int i = 0; i < length; i++) {
         hash ^= key[i];
         hash *= 16777619;
     }
@@ -248,13 +226,11 @@ static uint32_t hashString(const char *key, int length)
     return hash;
 }
 
-ObjString *takeString(DictuVM *vm, char *chars, int length)
-{
+ObjString *takeString(DictuVM *vm, char *chars, int length) {
     uint32_t hash = hashString(chars, length);
     ObjString *interned = tableFindString(&vm->strings, chars, length,
                                           hash);
-    if (interned != NULL)
-    {
+    if (interned != NULL) {
         FREE_ARRAY(vm, char, chars, length + 1);
         return interned;
     }
@@ -264,13 +240,11 @@ ObjString *takeString(DictuVM *vm, char *chars, int length)
     return allocateString(vm, chars, length, hash);
 }
 
-ObjString *copyString(DictuVM *vm, const char *chars, int length)
-{
+ObjString *copyString(DictuVM *vm, const char *chars, int length) {
     uint32_t hash = hashString(chars, length);
     ObjString *interned = tableFindString(&vm->strings, chars, length,
                                           hash);
-    if (interned != NULL)
-        return interned;
+    if (interned != NULL) return interned;
 
     char *heapChars = ALLOCATE(vm, char, length + 1);
     memcpy(heapChars, chars, length);
@@ -278,8 +252,7 @@ ObjString *copyString(DictuVM *vm, const char *chars, int length)
     return allocateString(vm, heapChars, length, hash);
 }
 
-ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot)
-{
+ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot) {
     ObjUpvalue *upvalue = ALLOCATE_OBJ(vm, ObjUpvalue, OBJ_UPVALUE);
     upvalue->closed = NIL_VAL;
     upvalue->value = slot;
@@ -288,52 +261,41 @@ ObjUpvalue *newUpvalue(DictuVM *vm, Value *slot)
     return upvalue;
 }
 
-char *listToString(Value value)
-{
+char *listToString(Value value) {
     int size = 50;
     ObjList *list = AS_LIST(value);
     char *listString = malloc(sizeof(char) * size);
     memcpy(listString, "[", 1);
     int listStringLength = 1;
 
-    for (int i = 0; i < list->values.count; ++i)
-    {
+    for (int i = 0; i < list->values.count; ++i) {
         Value listValue = list->values.values[i];
 
         char *element;
         int elementSize;
-        if (listValue == value)
-        {
+
+        if (listValue == value) {
             element = "[...]";
             elementSize = 5;
-        }
-        else if (IS_STRING(listValue))
-        {
+        } else if (IS_STRING(listValue)) {
             ObjString *s = AS_STRING(listValue);
             element = s->chars;
             elementSize = s->length;
-        }
-        else
-        {
+        } else {
             element = valueToString(listValue);
             elementSize = strlen(element);
         }
 
-        if (elementSize > (size - listStringLength - 6))
-        {
-            if (elementSize > size)
-            {
+        if (elementSize > (size - listStringLength - 6)) {
+            if (elementSize > size) {
                 size = size + elementSize * 2 + 6;
-            }
-            else
-            {
+            } else {
                 size = size * 2 + 6;
             }
 
             char *newB = realloc(listString, sizeof(char) * size);
 
-            if (newB == NULL)
-            {
+            if (newB == NULL) {
                 printf("Unable to allocate memory\n");
                 exit(71);
             }
@@ -341,27 +303,21 @@ char *listToString(Value value)
             listString = newB;
         }
 
-        if (listValue == value)
-        {
+        if (listValue == value) {
             memcpy(listString + listStringLength, element, elementSize);
             listStringLength += elementSize;
-        }
-        else if (IS_STRING(listValue))
-        {
+        } else if (IS_STRING(listValue)) {
             memcpy(listString + listStringLength, "\"", 1);
             memcpy(listString + listStringLength + 1, element, elementSize);
             memcpy(listString + listStringLength + 1 + elementSize, "\"", 1);
             listStringLength += elementSize + 2;
-        }
-        else
-        {
+        } else {
             memcpy(listString + listStringLength, element, elementSize);
             listStringLength += elementSize;
             free(element);
         }
 
-        if (i != list->values.count - 1)
-        {
+        if (i != list->values.count - 1) {
             memcpy(listString + listStringLength, ", ", 2);
             listStringLength += 2;
         }
@@ -373,152 +329,121 @@ char *listToString(Value value)
     return listString;
 }
 
-char *dictToString(Value value)
-{
-    int count = 0;
-    int size = 50;
-    ObjDict *dict = AS_DICT(value);
-    char *dictString = malloc(sizeof(char) * size);
-    memcpy(dictString, "{", 1);
-    int dictStringLength = 1;
+char *dictToString(Value value) {
+   int count = 0;
+   int size = 50;
+   ObjDict *dict = AS_DICT(value);
+   char *dictString = malloc(sizeof(char) * size);
+   memcpy(dictString, "{", 1);
+   int dictStringLength = 1;
 
-    for (int i = 0; i <= dict->capacityMask; ++i)
-    {
-        DictItem *item = &dict->entries[i];
-        if (IS_EMPTY(item->key))
-        {
-            continue;
-        }
+   for (int i = 0; i <= dict->capacityMask; ++i) {
+       DictItem *item = &dict->entries[i];
+       if (IS_EMPTY(item->key)) {
+           continue;
+       }
 
-        count++;
+       count++;
 
-        char *key;
-        int keySize;
+       char *key;
+       int keySize;
 
-        if (IS_STRING(item->key))
-        {
-            ObjString *s = AS_STRING(item->key);
-            key = s->chars;
-            keySize = s->length;
-        }
-        else
-        {
-            key = valueToString(item->key);
-            keySize = strlen(key);
-        }
+       if (IS_STRING(item->key)) {
+           ObjString *s = AS_STRING(item->key);
+           key = s->chars;
+           keySize = s->length;
+       } else {
+           key = valueToString(item->key);
+           keySize = strlen(key);
+       }
 
-        if (keySize > (size - dictStringLength - keySize - 4))
-        {
-            if (keySize > size)
-            {
-                size += keySize * 2 + 4;
-            }
-            else
-            {
-                size *= 2 + 4;
-            }
+       if (keySize > (size - dictStringLength - keySize - 4)) {
+           if (keySize > size) {
+               size += keySize * 2 + 4;
+           } else {
+               size *= 2 + 4;
+           }
 
-            char *newB = realloc(dictString, sizeof(char) * size);
+           char *newB = realloc(dictString, sizeof(char) * size);
 
-            if (newB == NULL)
-            {
-                printf("Unable to allocate memory\n");
-                exit(71);
-            }
+           if (newB == NULL) {
+               printf("Unable to allocate memory\n");
+               exit(71);
+           }
 
-            dictString = newB;
-        }
+           dictString = newB;
+       }
 
-        if (IS_STRING(item->key))
-        {
-            memcpy(dictString + dictStringLength, "\"", 1);
-            memcpy(dictString + dictStringLength + 1, key, keySize);
-            memcpy(dictString + dictStringLength + 1 + keySize, "\": ", 3);
-            dictStringLength += 4 + keySize;
-        }
-        else
-        {
-            memcpy(dictString + dictStringLength, key, keySize);
-            memcpy(dictString + dictStringLength + keySize, ": ", 2);
-            dictStringLength += 2 + keySize;
-            free(key);
-        }
+       if (IS_STRING(item->key)) {
+           memcpy(dictString + dictStringLength, "\"", 1);
+           memcpy(dictString + dictStringLength + 1, key, keySize);
+           memcpy(dictString + dictStringLength + 1 + keySize, "\": ", 3);
+           dictStringLength += 4 + keySize;
+       } else {
+           memcpy(dictString + dictStringLength, key, keySize);
+           memcpy(dictString + dictStringLength + keySize, ": ", 2);
+           dictStringLength += 2 + keySize;
+           free(key);
+       }
 
-        char *element;
-        int elementSize;
+       char *element;
+       int elementSize;
+       if (item->value == value){
+           element = "{...}";
+           elementSize = 5;
+       } else if (IS_STRING(item->value)) {
+           ObjString *s = AS_STRING(item->value);
+           element = s->chars;
+           elementSize = s->length;
+       } else {
+           element = valueToString(item->value);
+           elementSize = strlen(element);
+       }
 
-        if (item->value == value)
-        {
-            element = "{...}";
-            elementSize = 5;
-        }
-        else if (IS_STRING(item->value))
-        {
-            ObjString *s = AS_STRING(item->value);
-            element = s->chars;
-            elementSize = s->length;
-        }
-        else
-        {
-            element = valueToString(item->value);
-            elementSize = strlen(element);
-        }
+       if (elementSize > (size - dictStringLength - elementSize - 6)) {
+           if (elementSize > size) {
+               size += elementSize * 2 + 6;
+           } else {
+               size = size * 2 + 6;
+           }
 
-        if (elementSize > (size - dictStringLength - elementSize - 6))
-        {
-            if (elementSize > size)
-            {
-                size += elementSize * 2 + 6;
-            }
-            else
-            {
-                size = size * 2 + 6;
-            }
+           char *newB = realloc(dictString, sizeof(char) * size);
 
-            char *newB = realloc(dictString, sizeof(char) * size);
+           if (newB == NULL) {
+               printf("Unable to allocate memory\n");
+               exit(71);
+           }
 
-            if (newB == NULL)
-            {
-                printf("Unable to allocate memory\n");
-                exit(71);
-            }
+           dictString = newB;
+       }
 
-            dictString = newB;
-        }
-        if (item->value == value)
-        {
-            memcpy(dictString + dictStringLength, element, elementSize);
-            dictStringLength += elementSize;
-        }
-        else if (IS_STRING(item->value))
-        {
-            memcpy(dictString + dictStringLength, "\"", 1);
-            memcpy(dictString + dictStringLength + 1, element, elementSize);
-            memcpy(dictString + dictStringLength + 1 + elementSize, "\"", 1);
-            dictStringLength += 2 + elementSize;
-        }
-        else
-        {
-            memcpy(dictString + dictStringLength, element, elementSize);
-            dictStringLength += elementSize;
-            free(element);
-        }
+       if (item->value == value) {
+           memcpy(dictString + dictStringLength, element, elementSize);
+           dictStringLength += elementSize;
+       } else if (IS_STRING(item->value)) {
+           memcpy(dictString + dictStringLength, "\"", 1);
+           memcpy(dictString + dictStringLength + 1, element, elementSize);
+           memcpy(dictString + dictStringLength + 1 + elementSize, "\"", 1);
+           dictStringLength += 2 + elementSize;
+       } else {
+           memcpy(dictString + dictStringLength, element, elementSize);
+           dictStringLength += elementSize;
+           free(element);
+       }
 
-        if (count != dict->count)
-        {
-            memcpy(dictString + dictStringLength, ", ", 2);
-            dictStringLength += 2;
-        }
-    }
+       if (count != dict->count) {
+           memcpy(dictString + dictStringLength, ", ", 2);
+           dictStringLength += 2;
+       }
+   }
 
-    memcpy(dictString + dictStringLength, "}", 1);
-    dictString[dictStringLength + 1] = '\0';
+   memcpy(dictString + dictStringLength, "}", 1);
+   dictString[dictStringLength + 1] = '\0';
 
-    return dictString;
+   return dictString;
 }
 
-char *setToString(Value value)
-{
+char *setToString(Value value) {
     int count = 0;
     int size = 50;
     ObjSet *set = AS_SET(value);
@@ -526,8 +451,7 @@ char *setToString(Value value)
     memcpy(setString, "{", 1);
     int setStringLength = 1;
 
-    for (int i = 0; i <= set->capacityMask; ++i)
-    {
+    for (int i = 0; i <= set->capacityMask; ++i) {
         SetItem *item = &set->entries[i];
         if (IS_EMPTY(item->value) || item->deleted)
             continue;
@@ -537,33 +461,25 @@ char *setToString(Value value)
         char *element;
         int elementSize;
 
-        if (IS_STRING(item->value))
-        {
+        if (IS_STRING(item->value)) {
             ObjString *s = AS_STRING(item->value);
             element = s->chars;
             elementSize = s->length;
-        }
-        else
-        {
+        } else {
             element = valueToString(item->value);
             elementSize = strlen(element);
         }
 
-        if (elementSize > (size - setStringLength - 5))
-        {
-            if (elementSize > size * 2)
-            {
+        if (elementSize > (size - setStringLength - 5)) {
+            if (elementSize > size * 2) {
                 size += elementSize * 2 + 5;
-            }
-            else
-            {
+            } else {
                 size = size * 2 + 5;
             }
 
             char *newB = realloc(setString, sizeof(char) * size);
 
-            if (newB == NULL)
-            {
+            if (newB == NULL) {
                 printf("Unable to allocate memory\n");
                 exit(71);
             }
@@ -571,22 +487,19 @@ char *setToString(Value value)
             setString = newB;
         }
 
-        if (IS_STRING(item->value))
-        {
+
+        if (IS_STRING(item->value)) {
             memcpy(setString + setStringLength, "\"", 1);
             memcpy(setString + setStringLength + 1, element, elementSize);
             memcpy(setString + setStringLength + 1 + elementSize, "\"", 1);
             setStringLength += 2 + elementSize;
-        }
-        else
-        {
+        } else {
             memcpy(setString + setStringLength, element, elementSize);
             setStringLength += elementSize;
             free(element);
         }
 
-        if (count != set->count)
-        {
+        if (count != set->count) {
             memcpy(setString + setStringLength, ", ", 2);
             setStringLength += 2;
         }
@@ -598,8 +511,7 @@ char *setToString(Value value)
     return setString;
 }
 
-char *classToString(Value value)
-{
+char *classToString(Value value) {
     ObjClass *klass = AS_CLASS(value);
     char *classString = malloc(sizeof(char) * (klass->name->length + 7));
     memcpy(classString, "<Cls ", 5);
@@ -609,8 +521,7 @@ char *classToString(Value value)
     return classString;
 }
 
-char *instanceToString(Value value)
-{
+char *instanceToString(Value value) {
     ObjInstance *instance = AS_INSTANCE(value);
     char *instanceString = malloc(sizeof(char) * (instance->klass->name->length + 12));
     memcpy(instanceString, "<", 1);
@@ -620,207 +531,172 @@ char *instanceToString(Value value)
     return instanceString;
 }
 
-char *objectToString(Value value)
-{
-    switch (OBJ_TYPE(value))
-    {
-    case OBJ_MODULE:
-    {
-        ObjModule *module = AS_MODULE(value);
-        char *moduleString = malloc(sizeof(char) * (module->name->length + 11));
-        snprintf(moduleString, (module->name->length + 10), "<Module %s>", module->name->chars);
-        return moduleString;
-    }
-
-    case OBJ_CLASS:
-    {
-        if (IS_TRAIT(value))
-        {
-            ObjClass *trait = AS_CLASS(value);
-            char *traitString = malloc(sizeof(char) * (trait->name->length + 10));
-            snprintf(traitString, trait->name->length + 9, "<Trait %s>", trait->name->chars);
-            return traitString;
+char *objectToString(Value value) {
+    switch (OBJ_TYPE(value)) {
+        case OBJ_MODULE: {
+            ObjModule *module = AS_MODULE(value);
+            char *moduleString = malloc(sizeof(char) * (module->name->length + 11));
+            snprintf(moduleString, (module->name->length + 10), "<Module %s>", module->name->chars);
+            return moduleString;
         }
 
-        return classToString(value);
-    }
-
-    case OBJ_ENUM:
-    {
-        ObjEnum *enumObj = AS_ENUM(value);
-        char *enumString = malloc(sizeof(char) * (enumObj->name->length + 8));
-        memcpy(enumString, "<Enum ", 6);
-        memcpy(enumString + 6, enumObj->name->chars, enumObj->name->length);
-        memcpy(enumString + 6 + enumObj->name->length, ">", 1);
-
-        enumString[7 + enumObj->name->length] = '\0';
-
-        return enumString;
-    }
-
-    case OBJ_BOUND_METHOD:
-    {
-        ObjBoundMethod *method = AS_BOUND_METHOD(value);
-        char *methodString;
-
-        if (method->method->function->name != NULL)
-        {
-            switch (method->method->function->type)
-            {
-            case TYPE_STATIC:
-            {
-                methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
-                snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
-                break;
+        case OBJ_CLASS: {
+            if (IS_TRAIT(value)) {
+                ObjClass *trait = AS_CLASS(value);
+                char *traitString = malloc(sizeof(char) * (trait->name->length + 10));
+                snprintf(traitString, trait->name->length + 9, "<Trait %s>", trait->name->chars);
+                return traitString;
             }
 
-            default:
-            {
-                methodString = malloc(sizeof(char) * (method->method->function->name->length + 16));
-                snprintf(methodString, method->method->function->name->length + 16, "<Bound Method %s>", method->method->function->name->chars);
-                break;
+            return classToString(value);
+        }
+
+        case OBJ_ENUM: {
+            ObjEnum *enumObj = AS_ENUM(value);
+            char *enumString = malloc(sizeof(char) * (enumObj->name->length + 8));
+            memcpy(enumString, "<Enum ", 6);
+            memcpy(enumString + 6, enumObj->name->chars, enumObj->name->length);
+            memcpy(enumString + 6 + enumObj->name->length, ">", 1);
+
+            enumString[7 + enumObj->name->length] = '\0';
+
+            return enumString;
+        }
+
+        case OBJ_BOUND_METHOD: {
+            ObjBoundMethod *method = AS_BOUND_METHOD(value);
+            char *methodString;
+
+            if (method->method->function->name != NULL) {
+                switch (method->method->function->type) {
+                    case TYPE_STATIC: {
+                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 17));
+                        snprintf(methodString, method->method->function->name->length + 17, "<Static Method %s>", method->method->function->name->chars);
+                        break;
+                    }
+
+                    default: {
+                        methodString = malloc(sizeof(char) * (method->method->function->name->length + 16));
+                        snprintf(methodString, method->method->function->name->length + 16, "<Bound Method %s>", method->method->function->name->chars);
+                        break;
+                    }
+                }
+            } else {
+                switch (method->method->function->type) {
+                    case TYPE_STATIC: {
+                        methodString = malloc(sizeof(char) * 16);
+                        memcpy(methodString, "<Static Method>", 15);
+                        methodString[15] = '\0';
+                        break;
+                    }
+
+                    default: {
+                        methodString = malloc(sizeof(char) * 15);
+                        memcpy(methodString, "<Bound Method>", 14);
+                        methodString[14] = '\0';
+                        break;
+                    }
+                }
             }
+
+            return methodString;
+        }
+
+        case OBJ_CLOSURE: {
+            ObjClosure *closure = AS_CLOSURE(value);
+            char *closureString;
+
+            if (closure->function->name != NULL) {
+                closureString = malloc(sizeof(char) * (closure->function->name->length + 6));
+                snprintf(closureString, closure->function->name->length + 6, "<fn %s>", closure->function->name->chars);
+            } else {
+                closureString = malloc(sizeof(char) * 9);
+                memcpy(closureString, "<Script>", 8);
+                closureString[8] = '\0';
             }
+
+            return closureString;
         }
-        else
-        {
-            switch (method->method->function->type)
-            {
-            case TYPE_STATIC:
-            {
-                methodString = malloc(sizeof(char) * 16);
-                memcpy(methodString, "<Static Method>", 15);
-                methodString[15] = '\0';
-                break;
+
+        case OBJ_FUNCTION: {
+            ObjFunction *function = AS_FUNCTION(value);
+            char *functionString;
+
+            if (function->name != NULL) {
+                functionString = malloc(sizeof(char) * (function->name->length + 6));
+                snprintf(functionString, function->name->length + 6, "<fn %s>", function->name->chars);
+            } else {
+                functionString = malloc(sizeof(char) * 5);
+                memcpy(functionString, "<fn>", 4);
+                functionString[4] = '\0';
             }
 
-            default:
-            {
-                methodString = malloc(sizeof(char) * 15);
-                memcpy(methodString, "<Bound Method>", 14);
-                methodString[14] = '\0';
-                break;
+            return functionString;
+        }
+
+        case OBJ_INSTANCE: {
+            return instanceToString(value);
+        }
+
+        case OBJ_NATIVE: {
+            char *nativeString = malloc(sizeof(char) * 12);
+            memcpy(nativeString, "<fn native>", 11);
+            nativeString[11] = '\0';
+            return nativeString;
+        }
+
+        case OBJ_STRING: {
+            ObjString *stringObj = AS_STRING(value);
+            char *string = malloc(sizeof(char) * stringObj->length + 1);
+            memcpy(string, stringObj->chars, stringObj->length);
+            string[stringObj->length] = '\0';
+            return string;
+        }
+
+        case OBJ_FILE: {
+            ObjFile *file = AS_FILE(value);
+            char *fileString = malloc(sizeof(char) * (strlen(file->path) + 8));
+            snprintf(fileString, strlen(file->path) + 8, "<File %s>", file->path);
+            return fileString;
+        }
+
+        case OBJ_LIST: {
+            return listToString(value);
+        }
+
+        case OBJ_DICT: {
+            return dictToString(value);
+        }
+
+        case OBJ_SET: {
+            return setToString(value);
+        }
+
+        case OBJ_UPVALUE: {
+            char *upvalueString = malloc(sizeof(char) * 8);
+            memcpy(upvalueString, "upvalue", 7);
+            upvalueString[7] = '\0';
+            return upvalueString;
+        }
+
+        case OBJ_ABSTRACT: {
+            ObjAbstract *abstract = AS_ABSTRACT(value);
+
+            return abstract->type(abstract);
+        }
+
+        case OBJ_RESULT: {
+            ObjResult *result = AS_RESULT(value);
+            if (result->status == SUCCESS) {
+                char *resultString = malloc(sizeof(char) * 13);
+                snprintf(resultString, 13, "<Result Suc>");
+                return resultString;
             }
-            }
-        }
 
-        return methodString;
-    }
-
-    case OBJ_CLOSURE:
-    {
-        ObjClosure *closure = AS_CLOSURE(value);
-        char *closureString;
-
-        if (closure->function->name != NULL)
-        {
-            closureString = malloc(sizeof(char) * (closure->function->name->length + 6));
-            snprintf(closureString, closure->function->name->length + 6, "<fn %s>", closure->function->name->chars);
-        }
-        else
-        {
-            closureString = malloc(sizeof(char) * 9);
-            memcpy(closureString, "<Script>", 8);
-            closureString[8] = '\0';
-        }
-
-        return closureString;
-    }
-
-    case OBJ_FUNCTION:
-    {
-        ObjFunction *function = AS_FUNCTION(value);
-        char *functionString;
-
-        if (function->name != NULL)
-        {
-            functionString = malloc(sizeof(char) * (function->name->length + 6));
-            snprintf(functionString, function->name->length + 6, "<fn %s>", function->name->chars);
-        }
-        else
-        {
-            functionString = malloc(sizeof(char) * 5);
-            memcpy(functionString, "<fn>", 4);
-            functionString[4] = '\0';
-        }
-
-        return functionString;
-    }
-
-    case OBJ_INSTANCE:
-    {
-        return instanceToString(value);
-    }
-
-    case OBJ_NATIVE:
-    {
-        char *nativeString = malloc(sizeof(char) * 12);
-        memcpy(nativeString, "<fn native>", 11);
-        nativeString[11] = '\0';
-        return nativeString;
-    }
-
-    case OBJ_STRING:
-    {
-        ObjString *stringObj = AS_STRING(value);
-        char *string = malloc(sizeof(char) * stringObj->length + 1);
-        memcpy(string, stringObj->chars, stringObj->length);
-        string[stringObj->length] = '\0';
-        return string;
-    }
-
-    case OBJ_FILE:
-    {
-        ObjFile *file = AS_FILE(value);
-        char *fileString = malloc(sizeof(char) * (strlen(file->path) + 8));
-        snprintf(fileString, strlen(file->path) + 8, "<File %s>", file->path);
-        return fileString;
-    }
-
-    case OBJ_LIST:
-    {
-        return listToString(value);
-    }
-
-    case OBJ_DICT:
-    {
-        return dictToString(value);
-    }
-
-    case OBJ_SET:
-    {
-        return setToString(value);
-    }
-
-    case OBJ_UPVALUE:
-    {
-        char *upvalueString = malloc(sizeof(char) * 8);
-        memcpy(upvalueString, "upvalue", 7);
-        upvalueString[7] = '\0';
-        return upvalueString;
-    }
-
-    case OBJ_ABSTRACT:
-    {
-        ObjAbstract *abstract = AS_ABSTRACT(value);
-
-        return abstract->type(abstract);
-    }
-
-    case OBJ_RESULT:
-    {
-        ObjResult *result = AS_RESULT(value);
-        if (result->status == SUCCESS)
-        {
             char *resultString = malloc(sizeof(char) * 13);
-            snprintf(resultString, 13, "<Result Suc>");
+            snprintf(resultString, 13, "<Result Err>");
             return resultString;
         }
-
-        char *resultString = malloc(sizeof(char) * 13);
-        snprintf(resultString, 13, "<Result Err>");
-        return resultString;
-    }
     }
 
     char *unknown = malloc(sizeof(char) * 9);


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

updated listToString and dictToString functions inorder to skip segfault


```
// for list
var x = [1,2,3];
x.push(x);
print(x);// [1,2,3,[...]
```
```
// for dict
var a ={1:2};
a[2]=a;
print(a);// {2: {...}, 1: 2}
```

<!-- Link the issue below if you are resolving an issue !-->

Resolves: #
  Self referencing datatypes #354
#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

- [ ] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).

- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Preview (Screenshots) :

<!-- If applicable attempt to explain the screenshots !-->

![image](https://user-images.githubusercontent.com/42714264/199579105-45503a45-490b-4bcf-8459-8620dff4a551.png)

