### PR TITLE
Stop at non-option argparse

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
     };
 
     struct argparse argparse;
-    argparse_init(&argparse, options, usage, 0);
+    argparse_init(&argparse, options, usage, ARGPARSE_STOP_AT_NON_OPTION);
     argc = argparse_parse(&argparse, argc, (const char **)argv);
 
     if (version) {


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

Resolves an issue where the argparse library used was erroring at an unknown argument, instead we pass a flag to stop argparse at an unknown command.

<!-- Link the issue below if you are resolving an issue !-->

Resolves: #561

#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [x] Bug fix

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).

- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Preview (Screenshots) :

<!-- If applicable attempt to explain the screenshots !-->
