### PR TITLE
Removed option to build without linenoise (depends on #597)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         os: [windows-2022, windows-2019]
 
-       steps:
+    steps:
       - uses: actions/checkout@v3
       - name: Make dictu and run tests (No HTTP)
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,11 +71,11 @@ jobs:
       matrix:
         os: [windows-2022, windows-2019]
 
-    steps:
+       steps:
       - uses: actions/checkout@v3
-      - name: Make dictu and run tests (No HTTP No Linenoise)
+      - name: Make dictu and run tests (No HTTP)
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -DCICD=1 -DDISABLE_HTTP=1 -DDISABLE_LINENOISE=1 -B build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION="10.0.18362.0" -DCICD=1 -DDISABLE_HTTP=1 -B build
           cmake --build build
           Debug\dictu.exe tests/runTests.du ci
   run-examples:

--- a/README.md
+++ b/README.md
@@ -75,25 +75,13 @@ $ cmake --build ./build
 $ ./dictu
 ```
 
-#### Compiling without linenoise
-[Linenoise](https://github.com/antirez/linenoise) is used within Dictu to enhance the REPL, however it does not build on windows
-systems so a simpler REPL solution is used.
-
-```bash
-$ git clone -b master https://github.com/dictu-lang/Dictu.git
-$ cd Dictu
-$ cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_LINENOISE=1 -B ./build 
-$ cmake --build ./build
-$ ./build/Dictu
-```
-
 ### Docker Installation
 
 Refer to [Dictu Docker](https://github.com/dictu-lang/Dictu/blob/develop/Docker/README.md)
 
 ### FreeBSD Installation
 
-For a full installation, make sure `curl` and `linenoise` are installed. They can be installed from the commands below:
+For a full installation, make sure `curl` is installed. It can be installed from the commands below:
 
 ```bash
 $ pkg install -y curl linenoise-ng

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,19 +1,11 @@
 set(DICTU_CLI_SRC main.c linenoise/linenoise.c linenoise/linenoise.h linenoise/stringbuf.c linenoise/stringbuf.h linenoise/utf8.c linenoise/utf8.h)
-set(DISABLE_LINENOISE OFF CACHE BOOL "Determines if the REPL uses linenoise. Linenoise requires termios.")
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-if((NOT WIN32) OR DISABLE_LINENOISE)
+if(NOT WIN32)
     list(FILTER DICTU_CLI_SRC EXCLUDE REGEX "linenoise-win32.c")
 endif()
 
-if(DISABLE_LINENOISE)
-    list(FILTER DICTU_CLI_SRC EXCLUDE REGEX "(linenoise|stringbuf|utf8)\.(c|h)")
-
-    add_compile_definitions(DISABLE_LINENOISE)
-else()
-    add_compile_definitions(USE_UTF8)
-endif()
-
+add_compile_definitions(USE_UTF8)
 add_executable(dictu ${DICTU_CLI_SRC})
 target_include_directories(dictu PUBLIC ${INCLUDE_DIR})
 target_link_libraries(dictu dictu_api_static)

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -11,7 +11,6 @@
 #include "../include/dictu_include.h"
 #include "argparse.h"
 
-#ifndef DISABLE_LINENOISE
 #include "linenoise/linenoise.h"
 
 static bool replCountBraces(char *line) {
@@ -62,14 +61,10 @@ static bool replCountQuotes(char *line) {
 
     return singleQuotes % 2 == 0 && doubleQuotes % 2 == 0;
 }
-#endif
 
 static void repl(DictuVM *vm) {
     printf(DICTU_STRING_VERSION);
     char *line;
-
-    #ifndef DISABLE_LINENOISE
-
     linenoiseHistoryLoad("history.txt");
 
     while((line = linenoise(">>> ")) != NULL) {
@@ -109,49 +104,6 @@ static void repl(DictuVM *vm) {
         free(line);
         free(fullLine);
     }
-    #else
-    #define BUFFER_SIZE 8
-    line = calloc(BUFFER_SIZE, sizeof(char));
-    if (line == NULL) {
-        printf("Unable to allocate memory\n");
-        exit(71);
-    }
-    size_t lineLength = 0;
-    size_t lineMemory = BUFFER_SIZE;
-
-    while (true) {
-        printf(">>> ");
-
-        char buffer[BUFFER_SIZE];
-        while (fgets(buffer, BUFFER_SIZE, stdin) != NULL) {
-            while (lineLength + BUFFER_SIZE > lineMemory) {
-                lineMemory *= 2;
-                line = realloc(line, lineMemory);
-                if (line == NULL) {
-                    printf("Unable to allocate memory\n");
-                    exit(71);
-                }
-            }
-            strcat(line, buffer);
-            lineLength += BUFFER_SIZE;
-            if (strlen(buffer) != BUFFER_SIZE - 1 || buffer[BUFFER_SIZE-2] == '\n') {
-                break;
-            }
-        }
-
-        if (line[0] == '\0') {
-            printf("\n");
-            break;
-        }
-
-        dictuInterpret(vm, "repl", line);
-        lineLength = 0;
-        line[0] = '\0';
-    }
-
-    #undef BUFFER_SIZE
-    free(line);
-    #endif
 }
 
 static char *readFile(const char *path) {


### PR DESCRIPTION
### Well detailed description of the change :

Removed DISABLE_LINENOISE macro and relevant code.

#

### Type of change:

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).
