### PR TITLE
add optional arg to readline for buffer size

### DIFF
--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -55,7 +55,7 @@ with("test.txt", "w") {
 
 ### Reading files
 
-There are two methods available when reading files: `read()` and `readLine()`. `read()` reads the entire file, and returns its content as a string. `readLine()` will read the file up to a new line character.
+There are two methods available when reading files: `read()` and `readLine()`. `read()` reads the entire file, and returns its content as a string. `readLine()` will read the file up to a new line character. It takes an optional arugment for the buffer read size.
 
 ```cs
 // Read entire file

--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -55,7 +55,9 @@ with("test.txt", "w") {
 
 ### Reading files
 
-There are two methods available when reading files: `read()` and `readLine()`. `read()` reads the entire file, and returns its content as a string. `readLine()` will read the file up to a new line character. It takes an optional arugment for the buffer read size.
+There are two methods available when reading files: `read()` and `readLine()`. `read()` reads the entire file, and returns its content as a string. `readLine()` will read the file up to a new line character.
+
+`readline()` can also take an optional argument for the buffer size.
 
 ```cs
 // Read entire file
@@ -71,6 +73,14 @@ with("test.txt", "r") {
     // When you reach the end of the file, nil is returned
     while((line = file.readLine()) != nil) {
         print(line);
+    }
+}
+
+with("test.txt", "r") {
+    var line;
+    // When you reach the end of the file, nil is returned
+    while((line = file.readLine(10)) != nil) {
+        print(line); // Will only read 10
     }
 }
 ```

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -90,11 +90,12 @@ static Value readFullFile(DictuVM *vm, int argCount, Value *args) {
 
 static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
     int readLineBufferSize = READLINE_BUFFER_SIZE;
+    if (argCount > 1) {
+        runtimeError(vm, "readLine() takes at most 1 argument (%d given)", argCount);
+        return EMPTY_VAL;
+    }
 
-    if (argCount > 0) {
-        // runtimeError(vm, "readLine() takes no arguments (%d given)", argCount);
-        // return EMPTY_VAL;
-
+    if (argCount == 1) {
         if (!IS_NUMBER(args[1])) {
             runtimeError(vm, "readLine() argument must be a number");
             return EMPTY_VAL;

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -89,11 +89,12 @@ static Value readFullFile(DictuVM *vm, int argCount, Value *args) {
 }
 
 static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
-    int readLineBufferSize = READLINE_BUFFER_SIZE;
     if (argCount > 1) {
         runtimeError(vm, "readLine() takes at most 1 argument (%d given)", argCount);
         return EMPTY_VAL;
     }
+
+    int readLineBufferSize = READLINE_BUFFER_SIZE;
 
     if (argCount == 1) {
         if (!IS_NUMBER(args[1])) {
@@ -104,8 +105,11 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
         readLineBufferSize = AS_NUMBER(args[1]);
     }
 
-    // TODO: This could be better
-    char line[readLineBufferSize];
+#ifdef _WIN32
+    char line[] = ALLOCATE(vm, char,readLineBufferSize);
+#else 
+    char line[readLineBufferSize]; 
+#endif
 
     ObjFile *file = AS_FILE(args[0]);
     if (fgets(line, readLineBufferSize, file->file) != NULL) {
@@ -117,6 +121,10 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
         }
         return OBJ_VAL(copyString(vm, line, lineLength));
     }
+
+#ifdef _WIN32
+    FREE(vm, char, line);
+#endif 
 
     return NIL_VAL;
 }

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -1,6 +1,8 @@
 #include "files.h"
 #include "../memory.h"
 
+#define READLINE_BUFFER_SIZE 4096
+
 static Value writeFile(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError(vm, "write() takes 1 argument (%d given)", argCount);
@@ -87,16 +89,25 @@ static Value readFullFile(DictuVM *vm, int argCount, Value *args) {
 }
 
 static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
-    if (argCount != 0) {
-        runtimeError(vm, "readLine() takes no arguments (%d given)", argCount);
-        return EMPTY_VAL;
+    int readLineBufferSize = READLINE_BUFFER_SIZE;
+
+    if (argCount > 0) {
+        // runtimeError(vm, "readLine() takes no arguments (%d given)", argCount);
+        // return EMPTY_VAL;
+
+        if (!IS_NUMBER(args[1])) {
+            runtimeError(vm, "readLine() argument must be a number");
+            return EMPTY_VAL;
+        }
+
+        readLineBufferSize = AS_NUMBER(args[1]);
     }
 
     // TODO: This could be better
-    char line[4096];
+    char line[readLineBufferSize];
 
     ObjFile *file = AS_FILE(args[0]);
-    if (fgets(line, 4096, file->file) != NULL) {
+    if (fgets(line, readLineBufferSize, file->file) != NULL) {
         int lineLength = strlen(line);
         // Remove newline char
         if (line[lineLength - 1] == '\n') {

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -100,7 +100,7 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
             return EMPTY_VAL;
         }
 
-        readLineBufferSize = AS_NUMBER(args[1]);
+        readLineBufferSize = AS_NUMBER(args[1]) + 1;
     }
 
 #ifdef _WIN32

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -104,7 +104,7 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
     }
 
 #ifdef _WIN32
-    char line[] = ALLOCATE(vm, char, readLineBufferSize);
+    char *line = ALLOCATE(vm, char, readLineBufferSize);
 #else 
     char line[readLineBufferSize]; 
 #endif

--- a/src/vm/datatypes/files.c
+++ b/src/vm/datatypes/files.c
@@ -1,8 +1,6 @@
 #include "files.h"
 #include "../memory.h"
 
-#define READLINE_BUFFER_SIZE 4096
-
 static Value writeFile(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError(vm, "write() takes 1 argument (%d given)", argCount);
@@ -94,7 +92,7 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
-    int readLineBufferSize = READLINE_BUFFER_SIZE;
+    int readLineBufferSize = 4096;
 
     if (argCount == 1) {
         if (!IS_NUMBER(args[1])) {
@@ -106,7 +104,7 @@ static Value readLineFile(DictuVM *vm, int argCount, Value *args) {
     }
 
 #ifdef _WIN32
-    char line[] = ALLOCATE(vm, char,readLineBufferSize);
+    char line[] = ALLOCATE(vm, char, readLineBufferSize);
 #else 
     char line[readLineBufferSize]; 
 #endif

--- a/tests/files/readLine.du
+++ b/tests/files/readLine.du
@@ -15,6 +15,16 @@ class TestFileReadline < UnitTest {
             }
         }
     }
+
+    testFileReadlineWithGivenBufferSize() {
+        with("tests/files/read.txt", "r") {
+            var line;
+            while ((line = file.readLine(16)) != nil) {
+                // Check readline works with empty lines as well
+                this.assertTruthy(line == "Dictu is great!" or line == "");
+            }
+        }
+    }
 }
 
 TestFileReadline().run();

--- a/tests/files/readLine.du
+++ b/tests/files/readLine.du
@@ -24,6 +24,24 @@ class TestFileReadline < UnitTest {
                 this.assertTruthy(line == "Dictu is great!" or line == "");
             }
         }
+
+        with("tests/files/read.txt", "r") {
+            this.assertTruthy(file.readLine(1) == "D");
+            this.assertTruthy(file.readLine(1) == "i");
+            this.assertTruthy(file.readLine(1) == "c");
+            this.assertTruthy(file.readLine(1) == "t");
+            this.assertTruthy(file.readLine(1) == "u");
+            this.assertTruthy(file.readLine(1) == " ");
+            this.assertTruthy(file.readLine(1) == "i");
+            this.assertTruthy(file.readLine(1) == "s");
+            this.assertTruthy(file.readLine(1) == " ");
+            this.assertTruthy(file.readLine(1) == "g");
+            this.assertTruthy(file.readLine(1) == "r");
+            this.assertTruthy(file.readLine(1) == "e");
+            this.assertTruthy(file.readLine(1) == "a");
+            this.assertTruthy(file.readLine(1) == "t");
+            this.assertTruthy(file.readLine(1) == "!");
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Brian Downs <brian.downs@gmail.com>

<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->

Adds optional arg to readline for the size buffer to use.

<!-- Link the issue below if you are resolving an issue !-->

Resolves: #

#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->


- [ ] Bug fix

- [x] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [x] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Preview (Screenshots) :

<!-- If applicable attempt to explain the screenshots !-->
