### PR TITLE
fix typo on  Parser import

### DIFF
--- a/docs/docs/standard-lib/argparse.md
+++ b/docs/docs/standard-lib/argparse.md
@@ -21,7 +21,7 @@ parent: Standard Library
 To make use of the Argparse module an import is required.
 
 ```cs
-from Argparse import Parse;
+from Argparse import Parser;
 ```
 
 ### New Parser(String, String, String) -> Parser


### PR DESCRIPTION
<!---- This is the PR Template !-->

<!-- Make sure to follow each step so that your PR is explained and easy to read !-->

<!-- This will allow maintainers and other potential contributors to understand the changes being carried out !-->

<!--- Thanks for considering that !-->

### Well detailed description of the change :

<!-- Explain what you have done !-->
Fixed a typo on the Argparse documentation, where it was importing `Parse` instead of `Parser`


<!-- Link the issue below if you are resolving an issue !-->

Resolves: #

#

### Type of change:

<!-- Please select relevant options -->

<!-- Add an x in [ ] if true !-->

<!-- Delete options that aren't relevant!-->

#

### Housekeeping

<!-- If adding a new test file, remember to include it in the relevant import file -->
- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).

- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Preview (Screenshots) :

<!-- If applicable attempt to explain the screenshots !-->
