### PR TITLE
un-auto load C module

### DIFF
--- a/src/optionals/c.c
+++ b/src/optionals/c.c
@@ -273,7 +273,6 @@ Value createCModule(DictuVM *vm) {
     defineNativeProperty(vm, &module->values, "EHWPOISON", NUMBER_VAL(EHWPOISON));
 #endif
 
-    //tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
 

--- a/src/optionals/c.c
+++ b/src/optionals/c.c
@@ -20,7 +20,7 @@ void getStrerror(char *buf, int error) {
 #endif
 }
 
-void createCModule(DictuVM *vm) {
+Value createCModule(DictuVM *vm) {
     ObjString *name = copyString(vm, "C", 1);
     push(vm, OBJ_VAL(name));
     ObjModule *module = newModule(vm, name);
@@ -273,8 +273,9 @@ void createCModule(DictuVM *vm) {
     defineNativeProperty(vm, &module->values, "EHWPOISON", NUMBER_VAL(EHWPOISON));
 #endif
 
-    tableSet(vm, &vm->globals, name, OBJ_VAL(module));
+    //tableSet(vm, &vm->globals, name, OBJ_VAL(module));
     pop(vm);
     pop(vm);
-}
 
+    return OBJ_VAL(module);
+}

--- a/src/optionals/c.h
+++ b/src/optionals/c.h
@@ -1,3 +1,6 @@
+#include "optionals.h"
+#include "../vm/vm.h"
+
 #ifndef dictu_c_h
 #define dictu_c_h
 
@@ -36,7 +39,7 @@
 #include "../vm/vm.h"
 #include "../vm/memory.h"
 
-void createCModule(DictuVM *vm);
+Value createCModule(DictuVM *vm);
 
 void getStrerror(char *buf, int error);
 

--- a/src/optionals/optionals.c
+++ b/src/optionals/optionals.c
@@ -1,6 +1,7 @@
 #include "optionals.h"
 
 BuiltinModules modules[] = {
+    {"C", &createCModule, false},
     {"Argparse", &createArgParseModule, false},
     {"Math", &createMathsModule, false},
     {"Env", &createEnvModule, true},

--- a/src/optionals/optionals.h
+++ b/src/optionals/optionals.h
@@ -2,6 +2,7 @@
 #define dictu_optionals_h
 
 #include "../vm/util.h"
+#include "c.h"
 #include "argparse/argparse.h"
 #include "math.h"
 #include "env/env.h"

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -141,12 +141,6 @@ DictuVM *dictuInitVM(bool repl, int argc, char **argv) {
     declareInstanceMethods(vm);
     declareResultMethods(vm);
 
-    /**
-     * Native classes which are not required to be
-     * imported. For imported modules see optionals.c
-     */
-    createCModule(vm);
-
     if (vm->repl) {
         vm->replVar = copyString(vm, "_", 1);
     }


### PR DESCRIPTION
Resolves: #637 


### What's Changed:

Updated the code to require the C module to be loaded like all other modules and not be autoloaded with the VM.

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
