### PR TITLE
Argparse

### DIFF
--- a/docs/docs/standard-lib/argparse.md
+++ b/docs/docs/standard-lib/argparse.md
@@ -24,12 +24,16 @@ To make use of the Argparse module an import is required.
 from Argparse import Parser;
 ```
 
-### New Parser(String, String, String) -> Parser
+### New Parser(String, String, String -> Optional) -> Parser
 
-To create a new parser instance, call the `Parser` class with the 3 required string arguments; name, description, and user provided usage.
+To create a new parser instance, call the `Parser` class with the 2 required string arguments; name, description.
+
+You can optionally pass in a user generated usage for the Parser
 
 ```cs
-var parser = Parser("prog_name", "Program to do all the things", "");
+const parser = Parser("prog_name", "Program to do all the things");
+// 
+const parser = Parser("prog_name", "Program to do all the things", "User defined usage string");
 ```
 
 ### Parse.addString(String, String, Bool, string -> Optional)
@@ -64,7 +68,24 @@ To add a new list argument, call the method below with at least the 3 required a
 parser.addList("-u", "active users", true, "users");
 ```
 
-### Parser.parse() -> Result\<Dict>
+### Parser.usage() -> String
+
+The Parser class will create a helpful output based on the arguments added to the parser class for you, this can be used to populate a `--help` argument.
+
+```cs
+const parser = Parser("Code!", "Some code");
+parser.addBool("--myOption", "Some useful boolean option", false);
+print(parser.usage());
+
+// Output
+usage: Code!
+    Some code
+
+    --myOption    Some useful boolean option
+
+```
+
+### Parser.parse() -> Result\<Args>
 
 The `parse` method needs to be called to process the given flags against the configured flags. `parse` returns a `Result` value that, on success, will need to be unwrapped to access an instance of the `Args` class.
 
@@ -78,8 +99,23 @@ const args = parser.parse().match(
 );
 ```
 
-The value of type `Args` will be instantiated with fields matching the configured flags or the given metavar names. Below is an example using the list argument example from above.
+The value of type `Args` will be instantiated with fields matching the configured flags or the given metavar names.
+
+If the option was not marked as required and a value for that given argument was not passed then it will have a `nil` value.
 
 ```cs
-print("Users: {}".format(args.users));
+const parser = Parser("Code!", "Some code");
+parser.addString("--option", "Some useful string option", false);
+parser.addString("--option1", "Some useful string option", false);
+const args = parser.parse().unwrap();
+
+print(args.option, args.option1);
+```
+
+CLI Input / Output:
+
+```
+$ dictu argparse.du --option "Hello"
+hello
+nil
 ```

--- a/src/optionals/argparse/argparse.c
+++ b/src/optionals/argparse/argparse.c
@@ -9,8 +9,5 @@ Value createArgParseModule(DictuVM *vm) {
         return EMPTY_VAL;
     }
 
-    push(vm, OBJ_VAL(closure));
-    pop(vm);
-
     return OBJ_VAL(closure);
 }

--- a/src/optionals/argparse/argparse.du
+++ b/src/optionals/argparse/argparse.du
@@ -1,4 +1,3 @@
-import Argparse;
 import System;
 
 class Args {
@@ -7,12 +6,13 @@ class Args {
 
 class Parser {
     private args;
+    private preArgs;
+    private required;
 
-    var preArgs = [];
-    var required = [];
-
-    init(private name, private desc, private userUsage) {
+    init(private name, private desc, private userUsage = '') {
         this.args = Args(name, desc);
+        this.preArgs = [];
+        this.required = [];
     }
 
     private flagExists(flag) {
@@ -67,7 +67,11 @@ class Parser {
             var u = 'usage: {}\n    {}\n\n'.format(this.name, this.desc);
 
             for (var i = 0; i < this.preArgs.len(); i+=1) {
-                u += '    {}    {}\n'.format(this.preArgs[i]['flag'], this.preArgs[i]['desc']);
+                u += '    {}    {}{}\n'.format(
+                    this.preArgs[i]['flag'],
+                    this.preArgs[i]['desc'],
+                    this.preArgs[i]['required'] ? '    Required' : ''
+                );
             }
 
             return u;
@@ -93,6 +97,23 @@ class Parser {
         return false;
     }
 
+    private fillEmpty() {
+        for (var i = 0; i < this.preArgs.len(); i += 1) {
+            const arg = this.preArgs[i];
+
+            if (arg.get('metavar') and not this.args.getAttribute(arg['metavar'])) {
+                this.args.setAttribute(arg['metavar'], nil);
+
+                continue;
+            }
+
+            const flag = arg['flag'].replace('-', '');
+            if (not this.args.getAttribute(flag)) {
+                this.args.setAttribute(flag, nil);
+            }
+        }
+    }
+
     parse() {
         for (var i = 0; i < System.argv.len(); i+=1) {
             for (var j = 0; j < this.preArgs.len(); j+=1) {
@@ -115,7 +136,7 @@ class Parser {
                             this.args.setAttribute(this.preArgs[j]['flag'].replace('-', ''), System.argv[i+1].split(','));
                         }
                     } else if (this.preArgs[j]['type'] == 'number') {
-                        if (i == (System.argv.len() - 1) or System.argv[i+1][0] == '-') {
+                        if (i == (System.argv.len() - 1)) {
                             return Error('{} requires an argument'.format(System.argv[i]));
                         }
 
@@ -148,6 +169,8 @@ class Parser {
         if (not this.hasRequired()) {
             return Error('1 or more required flags missing');
         }
+
+        this.fillEmpty();
 
         return Success(this.args);
     }


### PR DESCRIPTION
# Argparse


### What's Changed:

This PR updates the Argparse builtin with the following changes:
- Allows negative numbers to be input on addNumber
- Mark user defined usage as optional when creating the Parser object
- Add parser.usage() to docs
- Make any non-required option that is not filled in be null
    - Rationale for this is it will reduce boilerplate of having to `.getAttrbibute()` rather than just `if (!args.<arrg>)`
- Mark preArgs and required as instance variables for the (probably very rare) occasion that we want multiple Parser objects
- Display if the argument is required in usage 

#

### Type of Change:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
