### PR TITLE
Correct type

### DIFF
--- a/src/optionals/system.c
+++ b/src/optionals/system.c
@@ -515,7 +515,7 @@ static Value copyFileNative(DictuVM *vm, int argCount, Value *args) {
         return newResultError(vm, "cannot open dst file");
     }
 
-    char buffer = fgetc(sf);
+    int buffer = fgetc(sf);
     while (buffer != EOF) {
         fputc(buffer, df);
         buffer = fgetc(sf);


### PR DESCRIPTION
# Correct type

### What's Changed:

EOF is defined as -1 so when comparing against a `char`(!= in copyFile) it's always going to be true

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
