### PR TITLE
Revert

### DIFF
--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -141,7 +141,6 @@ struct sObjList {
 typedef struct {
     Value key;
     Value value;
-    uint32_t psl;
 } DictItem;
 
 struct sObjDict {

--- a/tests/dicts/keys.du
+++ b/tests/dicts/keys.du
@@ -16,7 +16,7 @@ class TestDictKeys < UnitTest {
 
         this.assertEquals(dict.keys().len(), 5);
         this.assertType(dict.keys(), "list");
-        this.assertEquals(dict.keys(), [false, true, nil, 1, "test"]);
+        this.assertEquals(dict.keys(), [false, true, "test", 1, nil]);
     }
 }
 


### PR DESCRIPTION
# Revert Dicts

Resolves: #659 


### What's Changed:

Reverts table and dictionary to use the initial hashtable implementation as there was issues with the robinhood scheme. Definitely worth revisiting this as Table Dicts and Sets have very similar (yet 3 unique) implementations that can be consolidated 

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
