### PR TITLE
Fix issue with abstracts not being able to grey

### DIFF
--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -168,6 +168,9 @@ static void blackenObject(DictuVM *vm, Obj *object) {
         case OBJ_ABSTRACT: {
             ObjAbstract *abstract = (ObjAbstract *) object;
             grayTable(vm, &abstract->values);
+            if (abstract->grayFunc != NULL) {
+                abstract->grayFunc(vm, abstract);
+            }
             break;
         }
 

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -189,6 +189,7 @@ ObjAbstract *newAbstract(DictuVM *vm, AbstractFreeFn func, AbstractTypeFn type) 
     abstract->data = NULL;
     abstract->func = func;
     abstract->type = type;
+    abstract->grayFunc = NULL;
     initTable(&abstract->values);
 
     return abstract;

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -170,6 +170,7 @@ struct sObjFile {
 };
 
 typedef void (*AbstractFreeFn)(DictuVM *vm, ObjAbstract *abstract);
+typedef void (*AbstractGrayFn)(DictuVM *vm, ObjAbstract *abstract);
 typedef char* (*AbstractTypeFn)(ObjAbstract *abstract);
 
 struct sObjAbstract {
@@ -177,6 +178,7 @@ struct sObjAbstract {
     Table values;
     void *data;
     AbstractFreeFn func;
+    AbstractGrayFn grayFunc;
     AbstractTypeFn type;
 };
 

--- a/tests/queue/queue.du
+++ b/tests/queue/queue.du
@@ -79,7 +79,7 @@ class TestQueue < UnitTest {
         this.assertEquals(this.queue.cap(), 32);
     }
 
-    testQueueShrink() {
+    testQueuePopMany() {
         this.assertEquals(this.queue.cap(), this.defaultQueueSize);
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(def (x) => this.queue.push(x));
         this.assertEquals(this.queue.cap(), 32);
@@ -93,7 +93,6 @@ class TestQueue < UnitTest {
         this.queue.pop();
         this.queue.pop();
         this.queue.pop();
-        this.assertEquals(this.queue.cap(), 16);
     }
 }
 

--- a/tests/queue/queue.du
+++ b/tests/queue/queue.du
@@ -79,7 +79,7 @@ class TestQueue < UnitTest {
         this.assertEquals(this.queue.cap(), 32);
     }
 
-    testQueuePopMany() {
+    testQueueShrink() {
         this.assertEquals(this.queue.cap(), this.defaultQueueSize);
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(def (x) => this.queue.push(x));
         this.assertEquals(this.queue.cap(), 32);
@@ -93,6 +93,7 @@ class TestQueue < UnitTest {
         this.queue.pop();
         this.queue.pop();
         this.queue.pop();
+        this.assertEquals(this.queue.cap(), 16);
     }
 }
 

--- a/tests/stack/stack.du
+++ b/tests/stack/stack.du
@@ -71,22 +71,22 @@ class TestStack < UnitTest {
     }
 
     testStackGrow() {
-        [1, 2, 3, 4, 5, 6, 7, 8].forEach(def (x) => this.stack.push(x));
+        [1, 2, 3, 4, 5, 6, 7, 8].forEach(def (x) => this.stack.push(x.toString()));
         this.assertTruthy(this.stack.isFull());
         this.stack.push(this.testValue);
         this.assertFalsey(this.stack.isFull());
         this.assertEquals(this.stack.cap(), 16);
-        [1, 2, 3, 4, 5, 6, 7, 8].forEach(def (x) => this.stack.push(x));
+        [1, 2, 3, 4, 5, 6, 7, 8].forEach(def (x) => this.stack.push(x.toString()));
         this.assertFalsey(this.stack.isFull());
         this.assertEquals(this.stack.cap(), 32);
     }
 
     testStackShrink() {
         this.assertEquals(this.stack.cap(), this.defaultStackSize);
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].forEach(def (x) => this.stack.push(x));
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].forEach(def (x) => this.stack.push(x.toString()));
         this.assertEquals(this.stack.cap(), 32);
         const res = this.stack.pop();
-        this.assertEquals(res, 16);
+        this.assertEquals(res, "16");
         this.assertEquals(this.stack.cap(), 32);
         this.stack.pop();
         this.stack.pop();


### PR DESCRIPTION
# Abstracts


### What's Changed:

Fixes an issue where abstracts couldn't grey any values they kept track of. This PR now allows us to add a grayValue function to abstracts that can run and take care of any values that they keep track of.

It also fixes a couple of issues with the stack and queue modules

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
