### PR TITLE
Sqlite timeout

### DIFF
--- a/docs/docs/standard-lib/sqlite.md
+++ b/docs/docs/standard-lib/sqlite.md
@@ -25,9 +25,12 @@ Note: Unlike SQLite and most other libraries, foreign keys **are** enabled by de
 import Sqlite;
 ```
 
-### Sqlite.connect(String: database) -> Result<SQLite>
+### Sqlite.connect(String: database, timeout: number -> optional) -> Result<SQLite>
 
 This opens a connection to a SQLite database. Returns a Result type and on success wraps an abstract SQLite type.
+
+The second argument to connect is the amount of time it will sleep (total) in milliseconds if the database is currently locked. If 
+not set it will default to 5 seconds.
 
 Note: You can pass ":memory:" to open the SQLite database in memory rather than a file.
 


### PR DESCRIPTION
# Sqlite

Resolves: #667 


### What's Changed:

Adds the ability to set SQLite timeout. Currently if the database is locked it will immediately fail, instead we introduce a default timeout of 5 seconds

#

### Type of Change:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
