### PR TITLE
Add new Enum.values() method

### DIFF
--- a/docs/docs/enum.md
+++ b/docs/docs/enum.md
@@ -50,3 +50,17 @@ enum HeterogeneousEnum {
     c = def () => 10
 }
 ```
+
+### Enum.values()
+
+To get all values within an Enum you can use the `.values()` method. This will return a dictionary.
+
+```cs
+enum Test {
+    a = 10, // 10
+    b,      // 1
+    c       // 2
+}
+
+print(Test.values()); // {"c": 2, "a": 10, "b": 1}
+```

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -1977,7 +1977,7 @@ static void enumDeclaration(Compiler *compiler) {
 
     do {
         if (check(compiler, TOKEN_RIGHT_BRACE)) {
-            error(compiler->parser, "Trailing comma in enum declaration");
+            break;
         }
 
         consume(compiler, TOKEN_IDENTIFIER, "Expect enum value identifier.");

--- a/src/vm/datatypes/enums.c
+++ b/src/vm/datatypes/enums.c
@@ -1,0 +1,28 @@
+#include "enums.h"
+
+static Value values(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "values() takes 0 arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    ObjEnum *objEnum = AS_ENUM(args[0]);
+    ObjDict *dict = newDict(vm);
+    push(vm, OBJ_VAL(dict));
+
+    for (int i = 0; i < objEnum->values.capacityMask + 1; ++i) {
+        if (objEnum->values.entries[i].key == NULL) {
+            continue;
+        }
+
+        dictSet(vm, dict, OBJ_VAL(objEnum->values.entries[i].key), objEnum->values.entries[i].value);
+    }
+
+    pop(vm);
+
+    return OBJ_VAL(dict);
+}
+
+void declareEnumMethods(DictuVM *vm) {
+    defineNative(vm, &vm->enumMethods, "values", values);
+}

--- a/src/vm/datatypes/enums.h
+++ b/src/vm/datatypes/enums.h
@@ -1,0 +1,9 @@
+#ifndef dictu_api_enums_h
+#define dictu_api_enums_h
+
+#include "../common.h"
+#include "../util.h"
+
+void declareEnumMethods(DictuVM *vm);
+
+#endif //dictu_api_enums_h

--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -349,6 +349,7 @@ void collectGarbage(DictuVM *vm) {
     grayTable(vm, &vm->classMethods);
     grayTable(vm, &vm->instanceMethods);
     grayTable(vm, &vm->resultMethods);
+    grayTable(vm, &vm->enumMethods);
     grayCompilerRoots(vm);
     grayObject(vm, (Obj *) vm->initString);
     grayObject(vm, (Obj *) vm->annotationString);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -666,6 +666,12 @@ static bool invoke(DictuVM *vm, ObjString *name, int argCount, bool unpack) {
                     return call(vm, AS_CLOSURE(value), argCount + 1);
                 }
 
+                ObjEnum *enumObj = AS_ENUM(receiver);
+
+                if (tableGet(&enumObj->values, name, &value)) {
+                    return callValue(vm, value, argCount, false);
+                }
+
                 runtimeError(vm, "Enum has no method '%s'.", name->chars);
                 return false;
             }

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -39,6 +39,7 @@ struct _vm {
     Table classMethods;
     Table instanceMethods;
     Table resultMethods;
+    Table enumMethods;
     ObjString *initString;
     ObjString *annotationString;
     ObjString *replVar;

--- a/tests/enum/enum.du
+++ b/tests/enum/enum.du
@@ -82,7 +82,7 @@ class TestEnums < UnitTest {
             c = func
         }
 
-        const values = MyEnum.values();
+        const values = HeterogeneousEnum.values();
 
         this.assertEquals(values["a"], 0);
         this.assertEquals(values["b"], "string");

--- a/tests/enum/enum.du
+++ b/tests/enum/enum.du
@@ -58,6 +58,36 @@ class TestEnums < UnitTest {
         this.assertEquals(HeterogeneousEnum.c, func);
         this.assertEquals(HeterogeneousEnum.c(), 10);
     }
+
+    testGetValues() {
+        enum MyEnum {
+            a,
+            b,
+            c
+        }
+
+        const values = MyEnum.values();
+
+        this.assertEquals(values["a"], 0);
+        this.assertEquals(values["b"], 1);
+        this.assertEquals(values["c"], 2);
+    }
+
+    testGetValuesHeterogeneousEnum() {
+        const func = def () => 10;
+
+        enum HeterogeneousEnum {
+            a = 0,
+            b = "string",
+            c = func
+        }
+
+        const values = MyEnum.values();
+
+        this.assertEquals(values["a"], 0);
+        this.assertEquals(values["b"], "string");
+        this.assertEquals(values["c"], func);
+    }
 }
 
 TestEnums().run();


### PR DESCRIPTION
# Enums

Resolves: #658 


### What's Changed:

Add new Enum.values() method

Allow trailing comma in Enum declarations

#

### Type of Change:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
