### PR TITLE
[Feature] Extending sorting functionality for list with string elements

### DIFF
--- a/docs/docs/collections/lists.md
+++ b/docs/docs/collections/lists.md
@@ -222,7 +222,7 @@ print(list2); // [[10, 2]]
 ### Sorting Lists
 #### list.sort()
 
-To sort numeric lists (that is lists that contain only numbers) you can use the method
+To sort numeric lists and string lists (that is lists that contain only numbers or only strings) you can use the method
 sort.
 
 ```cs
@@ -232,6 +232,15 @@ print(list1); // [1, -1, 4, 2, 10, 5, 3]
 list1.sort();
 
 print(list1); // [-1, 1, 2, 3, 4, 5, 10]
+```
+
+```cs
+var list1 = ["zebra", "cat", "dino", "pig"];
+
+print(list1); // ["zebra", "cat", "dino", "pig"]
+list1.sort();
+
+print(list1); // ["cat", "dino", "pig", "zebra"]
 ```
 
 ### list.forEach(Func)

--- a/src/vm/datatypes/lists/lists.c
+++ b/src/vm/datatypes/lists/lists.c
@@ -305,14 +305,14 @@ static Value copyListDeep(DictuVM *vm, int argCount, Value *args) {
 }
 
 
-int compareString(ObjString* operandOne, ObjString* operandTwo){
+int compareString(ObjString *operandOne, ObjString *operandTwo) {
     return strcmp(operandOne->chars, operandTwo->chars);
 }
 
-static int partitionStringList(ObjList* arr, int start, int end) {
-    int pivot_index = (int)floor(start + end) / 2;
+static int partitionStringList(ObjList *arr, int start, int end) {
+    int pivot_index = (int) floor(start + end) / 2;
 
-    ObjString* pivot =  AS_STRING(arr->values.values[pivot_index]);
+    ObjString *pivot = AS_STRING(arr->values.values[pivot_index]);
 
     int i = start - 1;
     int j = end + 1;
@@ -320,11 +320,11 @@ static int partitionStringList(ObjList* arr, int start, int end) {
     for (;;) {
         do {
             i = i + 1;
-        } while(compareString(AS_STRING(arr->values.values[i]), pivot)<0);
+        } while (compareString(AS_STRING(arr->values.values[i]), pivot) < 0);
 
         do {
             j = j - 1;
-        } while(compareString(AS_STRING(arr->values.values[j]), pivot)>0);
+        } while (compareString(AS_STRING(arr->values.values[j]), pivot) > 0);
 
         if (i >= j) {
             return j;
@@ -332,17 +332,17 @@ static int partitionStringList(ObjList* arr, int start, int end) {
 
         // Swap arr[i] with arr[j]
         Value temp = arr->values.values[i];
-        
+
         arr->values.values[i] = arr->values.values[j];
         arr->values.values[j] = temp;
     }
 }
 
 
-static int partitionNumberList(ObjList* arr, int start, int end) {
-    int pivot_index = (int)floor(start + end) / 2;
+static int partitionNumberList(ObjList *arr, int start, int end) {
+    int pivot_index = (int) floor(start + end) / 2;
 
-    double pivot =  AS_NUMBER(arr->values.values[pivot_index]);
+    double pivot = AS_NUMBER(arr->values.values[pivot_index]);
 
     int i = start - 1;
     int j = end + 1;
@@ -350,11 +350,11 @@ static int partitionNumberList(ObjList* arr, int start, int end) {
     for (;;) {
         do {
             i = i + 1;
-        } while(AS_NUMBER(arr->values.values[i]) < pivot);
+        } while (AS_NUMBER(arr->values.values[i]) < pivot);
 
         do {
             j = j - 1;
-        } while(AS_NUMBER(arr->values.values[j]) > pivot);
+        } while (AS_NUMBER(arr->values.values[j]) > pivot);
 
         if (i >= j) {
             return j;
@@ -362,7 +362,7 @@ static int partitionNumberList(ObjList* arr, int start, int end) {
 
         // Swap arr[i] with arr[j]
         Value temp = arr->values.values[i];
-        
+
         arr->values.values[i] = arr->values.values[j];
         arr->values.values[j] = temp;
     }
@@ -372,14 +372,14 @@ static int partitionNumberList(ObjList* arr, int start, int end) {
 // Partition scheme.
 // Best Case O(n log n)
 // Worst Case O(n^2) (If the list is already sorted.) 
-static void quickSort(ObjList* arr, int start, int end, int (*partition)(ObjList*,int,int)) {
+static void quickSort(ObjList *arr, int start, int end, int (*partition)(ObjList *, int, int)) {
     while (start < end) {
         int part = partition(arr, start, end);
 
         // Recurse for the smaller halve.
         if (part - start < end - part) {
             quickSort(arr, start, part, partition);
-            
+
             start = start + 1;
         } else {
             quickSort(arr, part + 1, end, partition);
@@ -389,22 +389,22 @@ static void quickSort(ObjList* arr, int start, int end, int (*partition)(ObjList
     }
 }
 
-int isNumberList(ObjList* list){
+bool isNumberList(ObjList *list) {
     for (int i = 0; i < list->values.count; i++) {
         if (!IS_NUMBER(list->values.values[i])) {
-            return 0;
+            return false;
         }
     }
-    return 1;
+    return true;
 }
 
-int isStringList(ObjList* list){
+bool isStringList(ObjList *list) {
     for (int i = 0; i < list->values.count; i++) {
         if (!IS_STRING(list->values.values[i])) {
-            return 0;
+            return false;
         }
     }
-    return 1;
+    return true;
 }
 
 static Value sortList(DictuVM *vm, int argCount, Value *args) {
@@ -413,19 +413,20 @@ static Value sortList(DictuVM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
-    ObjList* list = AS_LIST(args[0]);
+    ObjList *list = AS_LIST(args[0]);
 
-    if(isNumberList(list)){
+    if (isNumberList(list)) {
         quickSort(list, 0, list->values.count - 1, &partitionNumberList);
         return NIL_VAL;
     }
 
-    if(isStringList(list)){
+    if (isStringList(list)) {
         quickSort(list, 0, list->values.count - 1, &partitionStringList);
         return NIL_VAL;
     }
 
-    runtimeError(vm, "sort() takes lists with either numbers or string (other types and heterotypic lists are not supported)");
+    runtimeError(vm,
+                 "sort() takes lists with either numbers or string (other types and heterotypic lists are not supported)");
     return EMPTY_VAL;
 }
 
@@ -435,7 +436,7 @@ static Value reverseList(DictuVM *vm, int argCount, Value *args) {
         return EMPTY_VAL;
     }
 
-    ObjList* list = AS_LIST(args[0]);
+    ObjList *list = AS_LIST(args[0]);
     int listLength = list->values.count;
 
     for (int i = 0; i < listLength / 2; i++) {

--- a/tests/lists/sort.du
+++ b/tests/lists/sort.du
@@ -6,14 +6,14 @@
 from UnitTest import UnitTest;
 
 class TestListSort < UnitTest {
-    testListSort() {
+    testNumberListSort() {
         const x = [3, 6, 4, 1, 5];
 
         x.sort();
         this.assertEquals(x, [1, 3, 4, 5, 6]);
     }
 
-    testListSortAlreadySorted() {
+    testNumberListSortAlreadySorted() {
         const x = [3, 6, 4, 1, 5];
 
         // Test sorting on an already sorted list.
@@ -21,7 +21,7 @@ class TestListSort < UnitTest {
         this.assertEquals(x, [1, 3, 4, 5, 6]);
     }
 
-    testListSortNegative() {
+    testNumberListSortNegative() {
         // Test sorting on negative values.
         const y = [3, 2, -1, 100, -3, 23, 1, -98];
 
@@ -32,7 +32,7 @@ class TestListSort < UnitTest {
         this.assertEquals(y, [-98, -3, -1, 1, 2, 3, 23, 100]);
     }
 
-    testListSortSameElements() {
+    testNumberListSortSameElements() {
         // Test sorting on lists containing equal elements
         const z = [3, 3, -3, 10, -3];
 
@@ -41,6 +41,31 @@ class TestListSort < UnitTest {
 
         z.sort();
         this.assertEquals(z, [-3, -3, 3, 3, 10]);
+    }
+
+    testStringListSort() {
+        const x = ["apple", "dog", "ceo", "bee", "aero", "deep", "zebra", "cat"];
+
+        x.sort();
+        this.assertEquals(x, ["aero", "apple", "bee", "cat", "ceo", "deep", "dog", "zebra"]);
+    }
+
+    testStringListSortAlreadySorted() {
+        const x = ["apple", "bee", "cat"];
+
+        x.sort();
+        this.assertEquals(x, ["apple", "bee", "cat"]);
+    }
+
+    testStringListSortSameElements() {
+        // Test sorting on lists containing equal elements
+        const z = ["abc", "cde", "abc", "cde"];
+
+        z.sort();
+        this.assertEquals(z, ["abc", "abc", "cde", "cde"]);
+
+        z.sort();
+        this.assertEquals(z, ["abc", "abc", "cde", "cde"]);
     }
 }
 


### PR DESCRIPTION
# Sorting lists with string elements

Resolves: #636 


### What's Changed:
Nothing modified, or breaking changes. Sort functionality is now extended to sort the list of strings also. 
(not supports heterotypic lists).

#

### Type of Change:

- [ ] Bug fix
- [ x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
