### PR TITLE
Add negate method to number type

### DIFF
--- a/docs/docs/variables.md
+++ b/docs/docs/variables.md
@@ -16,16 +16,16 @@ nav_order: 3
 ---
 ## Data types
 
-| Type | Example | Note |
-| --- | --- | --- |
-| String | `'foo'`, `"bar"` | You can use single or double quotes to represent strings in Dictu. |
-| Number | `100`, `100.5` | This data type includes both integers (whole numbers) and floats (numbers with decimals). |
-| Boolean | `true`, `false` | Fun fact: Boolean data types are named after George Boole. |
-| List | `[1, 2, ‘hi’, true, nil]` | Lists can contain any data type or combination of data types. |
+| Type       | Example                                            | Note                                                                                                                                                                          |
+| ---------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| String     | `'foo'`, `"bar"`                                   | You can use single or double quotes to represent strings in Dictu.                                                                                                            |
+| Number     | `100`, `100.5`                                     | This data type includes both integers (whole numbers) and floats (numbers with decimals).                                                                                     |
+| Boolean    | `true`, `false`                                    | Fun fact: Boolean data types are named after George Boole.                                                                                                                    |
+| List       | `[1, 2, ‘hi’, true, nil]`                          | Lists can contain any data type or combination of data types.                                                                                                                 |
 | Dictionary | `{"key1": 10, 2: "two", true: "true", nil: "nil"}` | Dictionaries have key-value pairs, like a dictionary (Word: Definition). Keys must be an immutable data type (strings, numbers, nil or boolean). Values can be any data type. |
-| Set | `set("1", 1, nil)` | Sets are unordered collections of immutable, unique values. You can create a set with the `set()` function. |
-| Nil | `nil` | Used to signify no value (much like null in other languages) |
-| Result | `Success`, `Error` | See [Error Handling section.](/docs/error-handling) |
+| Set        | `set("1", 1, nil)`                                 | Sets are unordered collections of immutable, unique values. You can create a set with the `set()` function.                                                                   |
+| Nil        | `nil`                                              | Used to signify no value (much like null in other languages)                                                                                                                  |
+| Result     | `Success`, `Error`                                 | See [Error Handling section.](/docs/error-handling)                                                                                                                           |
 
 ## Declaring a variable
 
@@ -48,6 +48,7 @@ Once a variable has been defined, `var` is no longer needed to update the value 
 ```cs
 var someNumber = 10;
 someNumber = someNumber + 13;
+someNumber = someNumber.negate();
 ```
 
 Variables can also change their data type without being redeclared with `var`:

--- a/src/vm/datatypes/number.c
+++ b/src/vm/datatypes/number.c
@@ -1,6 +1,17 @@
 #include "number.h"
 #include "../memory.h"
 
+static Value negateNumber(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 0) {
+        runtimeError(vm, "negate() takes no arguments (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    double number = AS_NUMBER(args[0]);
+
+    return NUMBER_VAL(number * -1);
+}
+
 static Value toStringNumber(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 0) {
         runtimeError(vm, "toString() takes no arguments (%d given)", argCount);
@@ -22,6 +33,7 @@ static Value toStringNumber(DictuVM *vm, int argCount, Value *args) {
 }
 
 void declareNumberMethods(DictuVM *vm) {
+    defineNative(vm, &vm->numberMethods, "negate", negateNumber);
     defineNative(vm, &vm->numberMethods, "toString", toStringNumber);
     defineNative(vm, &vm->numberMethods, "toBool", boolNative); // Defined in util
 }

--- a/tests/number/import.du
+++ b/tests/number/import.du
@@ -4,6 +4,7 @@
 * General import file for all the function tests
 */
 
+import "negate.du";
 import "toString.du";
 import "toBool.du";
 import "literals.du";

--- a/tests/number/negate.du
+++ b/tests/number/negate.du
@@ -1,0 +1,21 @@
+/**
+ * negate.du
+ *
+ * Testing the number.negate() method
+ *
+ * .negate() returns the negated value of the number
+ */
+
+from UnitTest import UnitTest;
+
+class NegateNumberTest < UnitTest {
+    testNumberNegate() {
+        const x = 100;
+        const n = x.negate();
+        this.assertEquals(n, -100);
+        const p = n.negate();
+        this.assertEquals(p, x);
+    }
+}
+
+NegateNumberTest().run();


### PR DESCRIPTION
Add negate method to number type

Resolves: #


### What's Changed:

Adds a new method, `negate`, to the number type.

### Type of Change:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [X] Tests have been updated to reflect the changes done within this PR (if applicable).
- [X] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
