### PR TITLE
Correct memory count

### DIFF
--- a/src/optionals/http/http.c
+++ b/src/optionals/http/http.c
@@ -243,16 +243,20 @@ static void createResponse(DictuVM *vm, Response *response) {
 
     response->len = 0;
     response->res = NULL;
+    response->firstIteration = true;
 }
 
 static size_t writeResponse(char *ptr, size_t size, size_t nmemb, void *data) {
     Response *response = (Response *) data;
     size_t new_len = response->len + size * nmemb;
-    response->res = GROW_ARRAY(response->vm, response->res, char, response->len, new_len + 1);
+    response->res = GROW_ARRAY(response->vm, response->res, char, response->len + !response->firstIteration, new_len + 1);
+    response->firstIteration = false;
+
     if (response->res == NULL) {
         printf("Unable to allocate memory\n");
         exit(71);
     }
+
     memcpy(response->res + response->len, ptr, size * nmemb);
     response->res[new_len] = '\0';
     response->len = new_len;

--- a/src/optionals/http/http.h
+++ b/src/optionals/http/http.h
@@ -14,6 +14,7 @@ typedef struct response {
     char *res;
     size_t len;
     long statusCode;
+    bool firstIteration;
 } Response;
 
 Value createHTTPModule(DictuVM *vm);


### PR DESCRIPTION
# HTTP

Resolves: #666


### What's Changed:

There wasn't actually an issue with the memory, just an issue with the count if the write function was called many times (larger HTTP responses). It was adding 1 to the count for the null terminator and not excluding that from the count on subsequent requests

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
