### PR TITLE
Fix issue where string was getting popped before created

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1873,9 +1873,10 @@ static DictuInterpretResult run(DictuVM *vm) {
                         index = string->length + index;
 
                     if (index >= 0 && index < string->length) {
+                        ObjString *newString = copyString(vm, &string->chars[index], 1);
                         pop(vm);
                         pop(vm);
-                        push(vm, OBJ_VAL(copyString(vm, &string->chars[index], 1)));
+                        push(vm, OBJ_VAL(newString));
                         DISPATCH();
                     }
 


### PR DESCRIPTION
# String Subscript


### What's Changed:

The string was being popped off the VM before the call to copyString, this meant the string was getting free'd and then the value was attempted to be used.

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
