### PR TITLE
Dont free path after first execution

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -153,9 +153,10 @@ static void repl(DictuVM *vm) {
         dictuInterpret(vm, "repl", statement);
 
         free(line);
-        free(dictuPath);
         free(statement);
     }
+
+    free(dictuPath);
 }
 
 static char *readFile(const char *path) {


### PR DESCRIPTION
# History

Resolves: #718 


### What's Changed:

The path string was being freed after the first statement had been executed, meaning further statements in the REPL was using a freed string 

#

### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [ ] Tests have been updated to reflect the changes done within this PR (if applicable).
- [ ] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
