### PR TITLE
fix: correctly return tombstone when theres no free element

### DIFF
--- a/src/vm/datatypes/dicts/dicts.c
+++ b/src/vm/datatypes/dicts/dicts.c
@@ -31,7 +31,7 @@ static Value lenDict(DictuVM *vm, int argCount, Value *args) {
     }
 
     ObjDict *dict = AS_DICT(args[0]);
-    return NUMBER_VAL(dict->count);
+    return NUMBER_VAL(dict->activeCount);
 }
 
 static Value keysDict(DictuVM *vm, int argCount, Value *args) {

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -167,6 +167,7 @@ ObjList *newList(DictuVM *vm) {
 ObjDict *newDict(DictuVM *vm) {
     ObjDict *dict = ALLOCATE_OBJ(vm, ObjDict, OBJ_DICT);
     dict->count = 0;
+    dict->activeCount = 0;
     dict->capacityMask = -1;
     dict->entries = NULL;
     return dict;

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -146,6 +146,7 @@ typedef struct {
 struct sObjDict {
     Obj obj;
     int count;
+    int activeCount;
     int capacityMask;
     DictItem *entries;
 };

--- a/src/vm/value.c
+++ b/src/vm/value.c
@@ -77,6 +77,7 @@ static DictItem *findDictEntry(DictItem *entries, int capacityMask,
                                Value key) {
     uint32_t index = hashValue(key) & capacityMask;
     DictItem *tombstone = NULL;
+    uint32_t count = 0;
 
     for (;;) {
         DictItem *entry = &entries[index];
@@ -88,6 +89,8 @@ static DictItem *findDictEntry(DictItem *entries, int capacityMask,
             } else {
                 // We found a tombstone.
                 if (tombstone == NULL) tombstone = entry;
+                if (count >= (uint32_t)capacityMask)
+                  return tombstone;
             }
         } else if (valuesEqual(key, entry->key)) {
             // We found the key.
@@ -97,6 +100,7 @@ static DictItem *findDictEntry(DictItem *entries, int capacityMask,
 //        printf("%d - ", index);
         index = (index + 1) & capacityMask;
 //        printf("%d - mask: %d\n", index, capacityMask);
+        count++;
     }
 }
 


### PR DESCRIPTION
# fix: correctly return tombstone when theres no free element

The dict findDictEntry function did not correctly handle the case when, a dict had no "free" slot but had tombstones, it would loop forever.

Resolves: https://github.com/dictu-lang/Dictu/issues/726


### What's Changed:
This fixes that by conditionally returning a tombstone when all other indexes where processed.


### Type of Change:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).


