### PR TITLE
feat: isSymbolicLink

### DIFF
--- a/docs/docs/standard-lib/path.md
+++ b/docs/docs/standard-lib/path.md
@@ -93,6 +93,16 @@ Checks whether a given path points to a directory or not.
 Path.isDir("/usr/bin/"); //true
 ```
 
+### Path.isSymbolicLink(String) -> Boolean
+
+Checks whether a given path is a symbolic link. 
+
+**Note:** This is not available on windows systems.
+
+```cs
+Path.isSymbolicLink("/usr/bin/"); //false
+```
+
 ### Path.listDir(String) -> List
 
 Returns a list of strings containing the contents of the input path.

--- a/src/optionals/path.c
+++ b/src/optionals/path.c
@@ -160,12 +160,12 @@ static Value isdirNative(DictuVM *vm, int argCount, Value *args) {
 
 static Value isSymlinkNative(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 1) {
-        runtimeError(vm, "isDir() takes 1 argument (%d given)", argCount);
+        runtimeError(vm, "isSymbolicLink() takes 1 argument (%d given)", argCount);
         return EMPTY_VAL;
     }
 
     if (!IS_STRING(args[0])) {
-        runtimeError(vm, "isDir() argument must be a string");
+        runtimeError(vm, "isSymbolicLink() argument must be a string");
         return EMPTY_VAL;
     }
 

--- a/src/optionals/path.c
+++ b/src/optionals/path.c
@@ -157,7 +157,7 @@ static Value isdirNative(DictuVM *vm, int argCount, Value *args) {
     return FALSE_VAL;
 
 }
-
+#ifndef _WIN32
 static Value isSymlinkNative(DictuVM *vm, int argCount, Value *args) {
     if (argCount != 1) {
         runtimeError(vm, "isSymbolicLink() takes 1 argument (%d given)", argCount);
@@ -182,6 +182,7 @@ static Value isSymlinkNative(DictuVM *vm, int argCount, Value *args) {
     return FALSE_VAL;
 
 }
+#endif
 
 static Value listDirNative(DictuVM *vm, int argCount, Value *args) {
     if (argCount > 1) {
@@ -358,7 +359,9 @@ Value createPathModule(DictuVM *vm) {
     defineNative(vm, &module->values, "dirname", dirnameNative);
     defineNative(vm, &module->values, "exists", existsNative);
     defineNative(vm, &module->values, "isDir", isdirNative);
+#ifndef _WIN32
     defineNative(vm, &module->values, "isSymbolicLink", isSymlinkNative);
+#endif
     defineNative(vm, &module->values, "listDir", listDirNative);
     defineNative(vm, &module->values, "join", joinNative);
 

--- a/src/optionals/path.c
+++ b/src/optionals/path.c
@@ -146,9 +146,37 @@ static Value isdirNative(DictuVM *vm, int argCount, Value *args) {
 
     char *path = AS_CSTRING(args[0]);
     struct stat path_stat;
-    stat(path, &path_stat);
+    int ret = stat(path, &path_stat);
+
+    if (ret < 0)
+        return FALSE_VAL;
 
     if (S_ISDIR(path_stat.st_mode))
+        return TRUE_VAL;
+
+    return FALSE_VAL;
+
+}
+
+static Value isSymlinkNative(DictuVM *vm, int argCount, Value *args) {
+    if (argCount != 1) {
+        runtimeError(vm, "isDir() takes 1 argument (%d given)", argCount);
+        return EMPTY_VAL;
+    }
+
+    if (!IS_STRING(args[0])) {
+        runtimeError(vm, "isDir() argument must be a string");
+        return EMPTY_VAL;
+    }
+
+    char *path = AS_CSTRING(args[0]);
+    struct stat path_stat;
+    int ret = lstat(path, &path_stat);
+
+    if(ret < 0)
+        return FALSE_VAL;
+
+    if (S_ISLNK(path_stat.st_mode))
         return TRUE_VAL;
 
     return FALSE_VAL;
@@ -330,6 +358,7 @@ Value createPathModule(DictuVM *vm) {
     defineNative(vm, &module->values, "dirname", dirnameNative);
     defineNative(vm, &module->values, "exists", existsNative);
     defineNative(vm, &module->values, "isDir", isdirNative);
+    defineNative(vm, &module->values, "isSymbolicLink", isSymlinkNative);
     defineNative(vm, &module->values, "listDir", listDirNative);
     defineNative(vm, &module->values, "join", joinNative);
 

--- a/tests/path/import.du
+++ b/tests/path/import.du
@@ -11,5 +11,6 @@ import "isAbsolute.du";
 import "realpath.du";
 import "exists.du";
 import "isDir.du";
+import "isSymbolicLink.du";
 import "join.du";
 import "listDir.du";

--- a/tests/path/isSymbolicLink.du
+++ b/tests/path/isSymbolicLink.du
@@ -1,0 +1,29 @@
+/**
+ * isDir.du
+ *
+ * Testing Path.isDir()
+ *
+ * Returns true if the given string is a path to a directory, else false. (Linux only)
+ */
+from UnitTest import UnitTest;
+
+import Path;
+import System;
+import Process;
+
+class TestPathIsSL < UnitTest {
+    setUp() {
+        Process.run(["ln", "-s", "README.md", "README.md.sl"]);
+    }
+    tearDown() {
+        System.remove("README.md.sl");
+    }
+    testIsSL() {
+        this.assertTruthy(Path.isSymbolicLink("README.md.sl"));
+        this.assertFalsey(Path.isSymbolicLink("README.md"));
+    }
+
+}
+
+if (System.platform != "windows")
+    TestPathIsSL().run();

--- a/tests/path/isSymbolicLink.du
+++ b/tests/path/isSymbolicLink.du
@@ -1,9 +1,9 @@
 /**
- * isDir.du
+ * isSymbolic.du
  *
- * Testing Path.isDir()
+ * Testing Path.isSymbolicLink()
  *
- * Returns true if the given string is a path to a directory, else false. (Linux only)
+ * Returns true if the given string is a symbolic Link, else false. (Linux only)
  */
 from UnitTest import UnitTest;
 


### PR DESCRIPTION
Theres a issue where isDir is checked on a broken symbolic link, it will return true falsely.
This adds checks for the return value of isDir and also adds a new function called `isSymbolicLink` which checks if a file is a symbolicLink



### What's Changed:


#

### Type of Change:

- [x] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#


