### PR TITLE
feat: allow custom var name for with statement and nesting of files.

### DIFF
--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -41,6 +41,14 @@ with("test.txt", "r") {
 // file is out of scope, and will the file will be closed for you
 ```
 
+### Custom name
+It is possible to append `as <name>` before the opening `{` in order to customise the Name of the variable within the block.
+```cs
+with("test.txt", "r") as myfile {
+    // file var is passed in here as myfile, NOT file.
+}
+```
+
 ### Writing to files
 
 There are two methods available when writing to a file: `write()` and `writeLine()`. `write()` simply writes strings to a file, `writeLine()` is exactly the same, except it appends a newline to the passed in string. Both functions return the amount of characters wrote to the file.

--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -45,7 +45,7 @@ with("test.txt", "r") {
 It is possible to append `as <name>` before the opening `{` in order to customise the Name of the variable within the block.
 ```cs
 with("test.txt", "r") as myfile {
-    // file var is passed in here as myfile, NOT file.
+    // file constant is passed in here as myfile, NOT file.
 }
 ```
 

--- a/docs/docs/files.md
+++ b/docs/docs/files.md
@@ -42,7 +42,7 @@ with("test.txt", "r") {
 ```
 
 ### Custom name
-It is possible to append `as <name>` before the opening `{` in order to customise the Name of the variable within the block.
+It is possible to append `as <name>` before the opening `{` in order to customise the name of the constant within the block.
 ```cs
 with("test.txt", "r") as myfile {
     // file constant is passed in here as myfile, NOT file.

--- a/ops/checkTests.du
+++ b/ops/checkTests.du
@@ -14,6 +14,7 @@ const ignored = {
     ],
     'files': [
         'read.txt',
+        'read2.txt',
     ],
     'strings': [
         'test',

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -162,7 +162,6 @@ static void initCompiler(Parser *parser, Compiler *compiler, Compiler *parent, F
     compiler->function = NULL;
     compiler->class = NULL;
     compiler->loop = NULL;
-    compiler->withBlock = -1;
     compiler->classAnnotations = NULL;
     compiler->methodAnnotations = NULL;
     compiler->fieldAnnotations = NULL;

--- a/src/vm/compiler.c
+++ b/src/vm/compiler.c
@@ -2545,7 +2545,7 @@ static void withStatement(Compiler *compiler) {
     Local *local = &compiler->locals[compiler->localCount++];
  
     if(match(compiler, TOKEN_AS)) {
-        consume(compiler, TOKEN_IDENTIFIER, "Expect indentifier.");
+        consume(compiler, TOKEN_IDENTIFIER, "Expect identifier.");
         local->name = compiler->parser->previous;
     } else {
         local->name = syntheticToken("file");

--- a/src/vm/compiler.h
+++ b/src/vm/compiler.h
@@ -102,7 +102,6 @@ typedef struct Compiler {
     Upvalue upvalues[UINT8_COUNT];
 
     int scopeDepth;
-    int withBlock;
     ObjDict *classAnnotations;
     ObjDict *methodAnnotations;
     ObjDict *fieldAnnotations;

--- a/src/vm/compiler.h
+++ b/src/vm/compiler.h
@@ -40,6 +40,8 @@ typedef struct {
 
     // True if it's a constant value.
     bool constant;
+
+    bool isFile;
 } Local;
 
 typedef struct {
@@ -100,7 +102,7 @@ typedef struct Compiler {
     Upvalue upvalues[UINT8_COUNT];
 
     int scopeDepth;
-    bool withBlock;
+    int withBlock;
     ObjDict *classAnnotations;
     ObjDict *methodAnnotations;
     ObjDict *fieldAnnotations;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2430,7 +2430,6 @@ static DictuInterpretResult runWithBreakFrame(DictuVM *vm, int breakFrame) {
             Value file = frame->slots[slot];
             ObjFile *fileObject = AS_FILE(file);
             fclose(fileObject->file);
-
             DISPATCH();
         }
     }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2430,6 +2430,7 @@ static DictuInterpretResult runWithBreakFrame(DictuVM *vm, int breakFrame) {
             Value file = frame->slots[slot];
             ObjFile *fileObject = AS_FILE(file);
             fclose(fileObject->file);
+
             DISPATCH();
         }
     }

--- a/tests/files/read.du
+++ b/tests/files/read.du
@@ -18,6 +18,7 @@ class TestFileReading < UnitTest {
         "Dictu is great!\n" +
         "Dictu is great!\n" +
         "Dictu is great!";
+    const EXPECTED2 = "This is another file";
 
     testFileRead() {
         var contents;
@@ -28,6 +29,29 @@ class TestFileReading < UnitTest {
 
         this.assertType(contents, "string");
         this.assertEquals(contents, TestFileReading.EXPECTED);
+    }
+    testFileReadCustomName() {
+        var contents;
+
+        with("tests/files/read.txt", "r") as f {
+            contents = f.read();
+        }
+
+        this.assertType(contents, "string");
+        this.assertEquals(contents, TestFileReading.EXPECTED);
+    }
+    testFileReadNested() {
+        var contents;
+
+        with("tests/files/read.txt", "r") {
+            contents = file.read();
+            with("tests/files/read2.txt", "r") as otherFile {
+                contents += otherFile.read();
+            }
+        }
+
+        this.assertType(contents, "string");
+        this.assertEquals(contents, TestFileReading.EXPECTED + TestFileReading.EXPECTED2);
     }
 }
 

--- a/tests/files/read.du
+++ b/tests/files/read.du
@@ -53,6 +53,22 @@ class TestFileReading < UnitTest {
         this.assertType(contents, "string");
         this.assertEquals(contents, TestFileReading.EXPECTED + TestFileReading.EXPECTED2);
     }
+    testFileReadNestedShadow() {
+        var contents;
+
+        with("tests/files/read.txt", "r") {
+            with("tests/files/read2.txt", "r") {
+                contents = file.read();
+            }
+            this.assertType(contents, "string");
+            this.assertEquals(contents, TestFileReading.EXPECTED2);
+            contents += file.read();
+        }
+
+        this.assertType(contents, "string");
+        this.assertEquals(contents, TestFileReading.EXPECTED2 + TestFileReading.EXPECTED);
+    }
+
 }
 
 TestFileReading().run();

--- a/tests/files/read2.txt
+++ b/tests/files/read2.txt
@@ -1,0 +1,1 @@
+This is another file

--- a/tests/files/write.du
+++ b/tests/files/write.du
@@ -38,6 +38,22 @@ class TestFileWrite < UnitTest {
             this.assertEquals(file.read(), "Dictu is great!Dictu is great!Dictu is great!");
         }
     }
+    testFileWriteCustomName() {
+        with("tests/files/read.txt", "w") as f {
+            // Save contents to reset the file
+            var count = f.write("Dictu is great!");
+            this.assertEquals(count, 15);
+            count = f.write("Dictu is great!");
+            this.assertEquals(count, 15);
+            count = f.write("Dictu is great!");
+            this.assertEquals(count, 15);
+        }
+
+        with("tests/files/read.txt", "r") as rf {
+            // Save contents to reset the file
+            this.assertEquals(rf.read(), "Dictu is great!Dictu is great!Dictu is great!");
+        }
+    }
 }
 
 TestFileWrite().run();


### PR DESCRIPTION
# feat: allow custom var name for with statement and nesting of files.



### What's Changed:
This refactors the logic in the compiler to allow files to have
custom variable names and also allow the nesting of multiple files
within each other. Both of which should be possible.
The latter is a bit questionable in terms of code quality but needed anyways.

#

### Type of Change:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Housekeeping:

- [x] Tests have been updated to reflect the changes done within this PR (if applicable).
- [x] Documentation has been updated to reflect the changes done within this PR (if applicable).

#

### Screenshots (If Applicable):
